### PR TITLE
Chore/connections table

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -5,4 +5,5 @@ ignores: [
   'htmx.org',
   'prettier-plugin-organize-imports',
   'reflect-metadata',
+  'pg',
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  postgres-veritable-ui:
+    image: postgres:16.2-alpine
+    container_name: postgres-veritable-ui
+    ports:
+      - 5432:5432
+    volumes:
+      - postgres-veritable-ui:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=veritable-ui
+
+volumes:
+  postgres-veritable-ui:

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,0 +1,35 @@
+// Update with your config settings.
+
+const pgConfig = {
+  client: 'pg',
+  timezone: 'UTC',
+  connection: {
+    host: process.env.DB_HOST || 'localhost',
+    database: process.env.DB_NAME || 'veritable-ui',
+    user: process.env.DB_USERNAME || 'postgres',
+    password: process.env.DB_PASSWORD || 'postgres',
+    port: process.env.DB_PORT || '5432',
+  },
+  pool: {
+    min: 2,
+    max: 10,
+  },
+  migrations: {
+    tableName: 'migrations',
+  },
+}
+
+module.exports = {
+  test: pgConfig,
+  development: pgConfig,
+  production: {
+    ...pgConfig,
+    connection: {
+      host: process.env.DB_HOST,
+      port: parseInt(process.env.DB_PORT || ''),
+      user: process.env.DB_USERNAME,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_NAME,
+    },
+  },
+}

--- a/migrations/20240507144207_init.js
+++ b/migrations/20240507144207_init.js
@@ -1,0 +1,17 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const [extInstalled] = await knex('pg_extension').select('*').where({ extname: 'uuid-ossp' })
+
+  if (!extInstalled) await knex.raw('CREATE EXTENSION "uuid-ossp"')
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.raw('DROP EXTENSION "uuid-ossp"')
+}

--- a/migrations/20240507145215_connection_table.js
+++ b/migrations/20240507145215_connection_table.js
@@ -1,0 +1,28 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const now = () => knex.fn.now()
+
+  await knex.schema.createTable('connection', (def) => {
+    def.uuid('id').defaultTo(knex.raw('uuid_generate_v4()'))
+    def.string('company_name').notNullable()
+    def
+      .enum('status', ['pending', 'unverified', 'verified_them', 'verified_us', 'verified_both', 'disconnected'], {
+        useNative: true,
+        enumName: 'connection_status',
+      })
+      .defaultTo('pending')
+    def.datetime('created_at').notNullable().defaultTo(now())
+    def.datetime('updated_at').notNullable().defaultTo(now())
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.dropTable('connection')
+}

--- a/migrations/20240507145215_connection_table.js
+++ b/migrations/20240507145215_connection_table.js
@@ -25,4 +25,5 @@ exports.up = async function (knex) {
  */
 exports.down = async function (knex) {
   await knex.schema.dropTable('connection')
+  await knex.schema.raw('DROP TYPE ??', ['connection_status'])
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@kitajs/html": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,14 @@
         "envalid": "^8.0.0",
         "express": "^4.19.2",
         "htmx.org": "^1.9.12",
+        "knex": "^3.1.0",
+        "pg": "^8.11.5",
         "pino": "^9.0.0",
         "pino-http": "^9.0.0",
         "swagger-ui-express": "^5.0.0",
         "tsoa": "^6.2.1",
-        "tsyringe": "^4.8.0"
+        "tsyringe": "^4.8.0",
+        "zod": "^3.23.6"
       },
       "devDependencies": {
         "@types/body-parser": "^1.19.5",
@@ -1719,6 +1722,19 @@
       "version": "1.1.4",
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "license": "MIT",
@@ -1871,7 +1887,6 @@
     },
     "node_modules/debug": {
       "version": "4.3.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -2076,6 +2091,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/esprima": {
@@ -2368,6 +2391,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/getopts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+      "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA=="
+    },
     "node_modules/glob": {
       "version": "10.3.12",
       "license": "ISC",
@@ -2657,6 +2693,14 @@
       "version": "2.0.4",
       "license": "ISC"
     },
+    "node_modules/interpret": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "license": "MIT",
@@ -2683,7 +2727,6 @@
     },
     "node_modules/is-core-module": {
       "version": "2.13.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.0"
@@ -3095,6 +3138,56 @@
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
       "dev": true
     },
+    "node_modules/knex": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-3.1.0.tgz",
+      "integrity": "sha512-GLoII6hR0c4ti243gMs5/1Rb3B+AjwMOfjYm97pu0FOQa7JH56hgBxYf5WK2525ceSbBY1cjeZ9yk99GPMB6Kw==",
+      "dependencies": {
+        "colorette": "2.0.19",
+        "commander": "^10.0.0",
+        "debug": "4.3.4",
+        "escalade": "^3.1.1",
+        "esm": "^3.2.25",
+        "get-package-type": "^0.1.0",
+        "getopts": "2.3.0",
+        "interpret": "^2.2.0",
+        "lodash": "^4.17.21",
+        "pg-connection-string": "2.6.2",
+        "rechoir": "^0.8.0",
+        "resolve-from": "^5.0.0",
+        "tarn": "^3.0.2",
+        "tildify": "2.0.0"
+      },
+      "bin": {
+        "knex": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        },
+        "mysql": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "pg-native": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        },
+        "tedious": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "dev": true,
@@ -3117,7 +3210,6 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.get": {
@@ -3390,7 +3482,6 @@
     },
     "node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/multimatch": {
@@ -3631,7 +3722,6 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -3674,6 +3764,92 @@
       "dev": true,
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.11.5",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.5.tgz",
+      "integrity": "sha512-jqgNHSKL5cbDjFlHyYsCXmQDrfIX/3RsNwYqpd4N0Kt8niLuNoRNH+aazv6cOd43gPh9Y4DjQCtb+X0MH0Hvnw==",
+      "dependencies": {
+        "pg-connection-string": "^2.6.4",
+        "pg-pool": "^3.6.2",
+        "pg-protocol": "^1.6.1",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
+      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
+      "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
+      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg=="
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg/node_modules/pg-connection-string": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
+      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA=="
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/picocolors": {
@@ -3838,6 +4014,41 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prettier": {
@@ -4005,6 +4216,17 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "dependencies": {
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "license": "Apache-2.0"
@@ -4023,7 +4245,6 @@
     },
     "node_modules/resolve": {
       "version": "1.22.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -4051,7 +4272,6 @@
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4399,7 +4619,6 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4425,12 +4644,28 @@
         "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
+    "node_modules/tarn": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
+      "integrity": "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
       "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
       "dependencies": {
         "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/tildify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
+      "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/to-fast-properties": {
@@ -4705,6 +4940,14 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "license": "ISC",
@@ -4775,6 +5018,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.6.tgz",
+      "integrity": "sha512-RTHJlZhsRbuA8Hmp/iNL7jnfc4nZishjsanDAfEY1QpDQZCahUp3xDzl+zfweE9BklxMUcgBgS1b7Lvie/ZVwA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "tsoa:watch": "node --watch-path=./src ./node_modules/.bin/tsoa -- spec-and-routes",
     "dev": "npm run tsoa:watch & node --import=tsimp/import --watch src/index.ts",
     "start": "node build/index.js",
+    "db:cmd": "node ./node_modules/.bin/knex",
+    "db:migrate": "npm run db:cmd -- migrate:latest",
+    "db:rollback": "npm run db:cmd -- migrate:rollback",
     "lint": "prettier -c ./src",
     "xss-scan": "xss-scan"
   },
@@ -33,11 +36,14 @@
     "envalid": "^8.0.0",
     "express": "^4.19.2",
     "htmx.org": "^1.9.12",
+    "knex": "^3.1.0",
+    "pg": "^8.11.5",
     "pino": "^9.0.0",
     "pino-http": "^9.0.0",
     "swagger-ui-express": "^5.0.0",
     "tsoa": "^6.2.1",
-    "tsyringe": "^4.8.0"
+    "tsyringe": "^4.8.0",
+    "zod": "^3.23.6"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "commonjs",

--- a/src/env.ts
+++ b/src/env.ts
@@ -4,6 +4,11 @@ import { singleton } from 'tsyringe'
 const envConfig = {
   PORT: envalid.port({ default: 3000 }),
   LOG_LEVEL: envalid.str({ default: 'info', devDefault: 'debug' }),
+  DB_HOST: envalid.host({ devDefault: 'localhost' }),
+  DB_NAME: envalid.str({ default: 'veritable_ui' }),
+  DB_USERNAME: envalid.str({ devDefault: 'postgres' }),
+  DB_PASSWORD: envalid.str({ devDefault: 'postgres' }),
+  DB_PORT: envalid.port({ default: 5432 }),
 }
 
 export type ENV_CONFIG = typeof envConfig

--- a/src/models/db/index.ts
+++ b/src/models/db/index.ts
@@ -1,0 +1,93 @@
+import knex from 'knex'
+import { container, singleton } from 'tsyringe'
+import { z } from 'zod'
+
+import { Env } from '../../env.js'
+import Zod, { IDatabase, Models, Order, TABLE, Update, Where, tablesList } from './types.js'
+import { reduceWhere } from './util.js'
+
+const env = container.resolve(Env)
+const clientSingleton = knex({
+  client: 'pg',
+  connection: {
+    host: env.get('DB_HOST'),
+    database: env.get('DB_NAME'),
+    user: env.get('DB_USERNAME'),
+    password: env.get('DB_PASSWORD'),
+    port: env.get('DB_PORT'),
+  },
+  pool: {
+    min: 2,
+    max: 10,
+  },
+  migrations: {
+    tableName: 'migrations',
+  },
+})
+
+@singleton()
+export default class Database {
+  private db: IDatabase
+
+  constructor(private client = clientSingleton) {
+    this.client = client
+    const models: IDatabase = tablesList.reduce((acc, name) => {
+      return {
+        [name]: () => clientSingleton(name),
+        ...acc,
+      }
+    }, {}) as IDatabase
+    this.db = models
+  }
+
+  // backlog item for if statement model === logic has been added and returns etc
+  insert = async <M extends TABLE>(
+    model: M,
+    record: Models[typeof model]['insert']
+  ): Promise<Models[typeof model]['get'][]> => {
+    return z.array(Zod[model].get).parse(await this.db[model]().insert(record).returning('*'))
+  }
+
+  delete = async <M extends TABLE>(model: M, where: Where<M>): Promise<void> => {
+    return this.db[model]()
+      .where(where || {})
+      .delete()
+  }
+
+  update = async <M extends TABLE>(
+    model: M,
+    where: Where<M>,
+    updates: Update<M>
+  ): Promise<Models[typeof model]['get'][]> => {
+    let query = this.db[model]().update({
+      ...updates,
+      updated_at: this.client.fn.now(),
+    })
+    query = reduceWhere(query, where)
+
+    return z.array(Zod[model].get).parse(await query.returning('*'))
+  }
+
+  get = async <M extends TABLE>(
+    model: M,
+    where?: Where<M>,
+    order?: Order<M>,
+    limit?: number
+  ): Promise<Models[typeof model]['get'][]> => {
+    let query = this.db[model]()
+    query = reduceWhere(query, where)
+    if (order && order.length !== 0) {
+      query = order.reduce((acc, [key, direction]) => acc.orderBy(key, direction), query)
+    }
+    if (limit !== undefined) query = query.limit(limit)
+    const result = await query
+    return z.array(Zod[model].get).parse(result)
+  }
+
+  withTransaction = (update: (db: Database) => Promise<void>) => {
+    return this.client.transaction(async (trx) => {
+      const decorated = new Database(trx)
+      await update(decorated)
+    })
+  }
+}

--- a/src/models/db/types.ts
+++ b/src/models/db/types.ts
@@ -1,0 +1,62 @@
+import { Knex } from 'knex'
+import { z } from 'zod'
+
+export const tablesList = ['connection'] as const
+
+const insertConnection = z.object({
+  company_name: z.string(),
+  connection_id: z.string(),
+  status: z.union([
+    z.literal('pending'),
+    z.literal('unverified'),
+    z.literal('verified_them'),
+    z.literal('verified_us'),
+    z.literal('verified_both'),
+    z.literal('disconnected'),
+  ]),
+})
+
+const Zod = {
+  connection: {
+    insert: insertConnection,
+    get: insertConnection.extend({
+      id: z.string(),
+      created_at: z.date(),
+      updated_at: z.date(),
+    }),
+  },
+}
+
+const { connection } = Zod
+
+export type InsertConnection = z.infer<typeof connection.insert>
+export type ConnectionRow = z.infer<typeof connection.get>
+
+export type TABLES_TUPLE = typeof tablesList
+export type TABLE = TABLES_TUPLE[number]
+export type Models = {
+  [key in TABLE]: {
+    get: z.infer<(typeof Zod)[key]['get']>
+    insert: z.infer<(typeof Zod)[key]['insert']>
+  }
+}
+
+type WhereComparison<M extends TABLE> = {
+  [key in keyof Models[M]['get']]: [
+    Extract<key, string>,
+    '=' | '>' | '>=' | '<' | '<=' | '<>',
+    Extract<Models[M]['get'][key], Knex.Value>,
+  ]
+}
+export type WhereMatch<M extends TABLE> = {
+  [key in keyof Models[M]['get']]?: Models[M]['get'][key]
+}
+
+export type Where<M extends TABLE> = WhereMatch<M> | (WhereMatch<M> | WhereComparison<M>[keyof Models[M]['get']])[]
+export type Order<M extends TABLE> = [keyof Models[M]['get'], 'asc' | 'desc'][]
+export type Update<M extends TABLE> = Partial<Models[M]['get']>
+export type IDatabase = {
+  [key in TABLE]: () => Knex.QueryBuilder
+}
+
+export default Zod

--- a/src/models/db/util.ts
+++ b/src/models/db/util.ts
@@ -1,0 +1,29 @@
+import knex from 'knex'
+import { TABLE, Where } from './types.js'
+
+// reduces the where condition on a knex query. Gracefully handles undefined values in WhereMatch objects
+export const reduceWhere = <M extends TABLE>(
+  query: knex.Knex.QueryBuilder,
+  where?: Where<M>
+): knex.Knex.QueryBuilder => {
+  if (where) {
+    if (!Array.isArray(where)) {
+      where = [where]
+    }
+    query = where.reduce((acc, w) => {
+      if (Array.isArray(w)) {
+        return acc.where(w[0], w[1], w[2])
+      }
+      return acc.where(
+        Object.entries(w).reduce(
+          (acc, [k, v]) => {
+            if (v !== undefined) acc[k] = v
+            return acc
+          },
+          {} as Record<string, unknown>
+        )
+      )
+    }, query)
+  }
+  return query
+}


### PR DESCRIPTION
Ticket: [VR-67](https://digicatapult.atlassian.net/browse/VR-70)

This PR adds the `connection` table which for now is simply the initial data we need:

* `company_name`
* `status`
* usual combination of `id`, `created_at`, `updated_at`

I've added the migration for this along with the db service as a model for the UI. One wrinkle I've had is with the package set to build to `commonjs` I cannot get knex the binary to work with Typescript. It's not a major issue as it only affects migrations and seeds but it's another nail in the knex coffin. We should really look for a replacement that we like.

[VR-67]: https://digicatapult.atlassian.net/browse/VR-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ