### PR TITLE
Fix IDP path vars to be strings not urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "commonjs",

--- a/src/env.ts
+++ b/src/env.ts
@@ -42,13 +42,13 @@ const envConfig = {
   IDP_INTERNAL_URL_PREFIX: envalid.url({
     devDefault: 'http://localhost:3080/realms/veritable/protocol/openid-connect',
   }),
-  IDP_AUTH_PATH: envalid.url({
+  IDP_AUTH_PATH: envalid.str({
     default: '/auth',
   }),
-  IDP_TOKEN_PATH: envalid.url({
+  IDP_TOKEN_PATH: envalid.str({
     default: '/token',
   }),
-  IDP_JWKS_PATH: envalid.url({
+  IDP_JWKS_PATH: envalid.str({
     default: '/certs',
   }),
   COMPANY_HOUSE_API_URL: envalid.str({ default: 'https://api.company-information.service.gov.uk' }),


### PR DESCRIPTION
Ticket: [VR-94](https://digicatapult.atlassian.net/browse/VR-94)

They are not urls and this causes issues in parsing

[VR-94]: https://digicatapult.atlassian.net/browse/VR-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ