### PR TITLE
Implement email sending service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^0.1.2",
@@ -22,6 +22,7 @@
         "express": "^4.19.2",
         "htmx.org": "^1.9.12",
         "knex": "^3.1.0",
+        "nodemailer": "^6.9.13",
         "pg": "^8.11.5",
         "pino": "^9.1.0",
         "pino-http": "^10.1.0",
@@ -38,6 +39,7 @@
         "@types/express": "^4.17.21",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.12.12",
+        "@types/nodemailer": "^6.4.15",
         "@types/sinon": "^17.0.3",
         "@types/swagger-ui-express": "^4.1.6",
         "chai": "^5.1.1",
@@ -1249,6 +1251,15 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.15",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.15.tgz",
+      "integrity": "sha512-0EBJxawVNjPkng1zm2vopRctuWVCxk34JcIlRuXSf54habUWdz1FB7wHDqOqvDa8Mtpt0Q3LTXQkAs2LNyK5jQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/parse-json": {
@@ -3764,6 +3775,14 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
       "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
       "dev": true
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.13.tgz",
+      "integrity": "sha512-7o38Yogx6krdoBf3jCAqnIN4oSQFx+fMa0I7dK1D+me9kBxx12D+/33wSb+fhOCtIxvYJ+4x4IMEhmhCKfAiOA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "commonjs",
@@ -41,6 +41,7 @@
     "express": "^4.19.2",
     "htmx.org": "^1.9.12",
     "knex": "^3.1.0",
+    "nodemailer": "^6.9.13",
     "pg": "^8.11.5",
     "pino": "^9.1.0",
     "pino-http": "^10.1.0",
@@ -57,6 +58,7 @@
     "@types/express": "^4.17.21",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.12.12",
+    "@types/nodemailer": "^6.4.15",
     "@types/sinon": "^17.0.3",
     "@types/swagger-ui-express": "^4.1.6",
     "chai": "^5.1.1",

--- a/src/env.ts
+++ b/src/env.ts
@@ -53,6 +53,8 @@ const envConfig = {
   }),
   COMPANY_HOUSE_API_URL: envalid.str({ default: 'https://api.company-information.service.gov.uk' }),
   COMPANY_PROFILE_API_KEY: envalid.str(),
+  EMAIL_TRANSPORT: envalid.str({ default: 'STREAM', choices: ['STREAM'] }),
+  EMAIL_FROM_ADDRESS: envalid.email({ default: 'hello@veritable.com' }),
 }
 
 export type ENV_CONFIG = typeof envConfig

--- a/src/models/companyHouseEntity.ts
+++ b/src/models/companyHouseEntity.ts
@@ -1,7 +1,8 @@
 import { injectable, singleton } from 'tsyringe'
 import { z } from 'zod'
-import { Env } from '../env'
-import { InternalError } from '../errors'
+
+import { Env } from '../env.js'
+import { InternalError } from '../errors.js'
 
 const companyProfileSchema = z.object({
   company_number: z.string(),

--- a/src/models/emailService/__tests__/index.test.ts
+++ b/src/models/emailService/__tests__/index.test.ts
@@ -1,0 +1,46 @@
+import { describe } from 'mocha'
+
+import pino from 'pino'
+import sinon from 'sinon'
+
+import { Env } from '../../../env.js'
+
+import EmailService from '../index.js'
+
+const mockEnv: Env = {
+  get: (name: string) => {
+    if (name === 'EMAIL_TRANSPORT') return 'STREAM'
+  },
+} as Env
+
+const mkMockLogger = () => {
+  const logger = {
+    info: sinon.stub<Parameters<pino.LogFn>, ReturnType<pino.LogFn>>(),
+    debug: sinon.stub<Parameters<pino.LogFn>, ReturnType<pino.LogFn>>(),
+  }
+  return logger
+}
+
+const mockTemplates = {
+  connection_invite: () => Promise.resolve({}),
+  connection_invite_admin: () => Promise.resolve({}),
+}
+
+describe('EmailService', () => {
+  let expect: Chai.ExpectStatic
+  before(async () => {
+    expect = (await import('chai')).expect
+  })
+
+  describe('sendMail', () => {
+    it('should log message details', async () => {
+      const logger = mkMockLogger()
+      const emailService = new EmailService(mockEnv, mockTemplates, logger as unknown as pino.Logger)
+
+      await emailService.sendMail('connection_invite', { to: 'user@example.com', invite: '1234567890987654321' })
+
+      expect(logger.info.callCount).to.equal(1)
+      expect(logger.debug.callCount).to.equal(2)
+    })
+  })
+})

--- a/src/models/emailService/index.ts
+++ b/src/models/emailService/index.ts
@@ -1,0 +1,49 @@
+import nodemailer, { SendMailOptions } from 'nodemailer'
+import { inject, injectable, singleton } from 'tsyringe'
+
+import { Env } from '../../env.js'
+import { Logger, type ILogger } from '../../logger.js'
+
+import Templates, { templateHandlers, templateName, templateParams } from './templates/index.js'
+
+@singleton()
+@injectable()
+export default class EmailService {
+  private templates: templateHandlers
+  private transportSendMail: nodemailer.Transporter['sendMail']
+
+  constructor(
+    private env: Env,
+    templates: Templates,
+    @inject(Logger) private logger: ILogger
+  ) {
+    this.templates = templates
+    this.transportSendMail = this.buildTransport()
+  }
+
+  private buildTransport(): typeof this.transportSendMail {
+    switch (this.env.get('EMAIL_TRANSPORT')) {
+      case 'STREAM':
+        const transport = nodemailer.createTransport({
+          streamTransport: true,
+          buffer: true,
+          newline: 'unix',
+        })
+        const logger = this.logger
+        return async function sendMail(this: typeof transport, options: SendMailOptions) {
+          const info = await this.sendMail(options)
+
+          logger.info('Sending email with message id %s', info.messageId)
+          logger.debug(`email envelope %s (from: %s, to %s)`, info.messageId, info.envelope.from, info.envelope.to)
+          logger.debug(`email contents %s: %s`, info.messageId, info.message.toString('utf8'))
+
+          return info
+        }.bind(transport)
+    }
+  }
+
+  async sendMail<T extends templateName>(name: T, ...params: templateParams[T]): Promise<void> {
+    const mail = await this.templates[name](this.env, ...params)
+    await this.transportSendMail(mail)
+  }
+}

--- a/src/models/emailService/templates/index.ts
+++ b/src/models/emailService/templates/index.ts
@@ -1,0 +1,30 @@
+import type { SendMailOptions } from 'nodemailer'
+
+import { singleton } from 'tsyringe'
+
+import { Env } from '../../../env.js'
+import invitation from './invitation.js'
+import invitationAdmin from './invitationAdmin.js'
+
+export type templateName = keyof templateParams
+export type templateHandlers = {
+  [key in templateName]: (env: Env, ...params: templateParams[key]) => Promise<SendMailOptions>
+}
+type ExtractParam<F extends { template: (env: Env, ...args: any) => any }> = F['template'] extends (
+  env: Env,
+  ...params: infer P
+) => any
+  ? P
+  : never
+
+export type templateParams = {
+  [invitation.name]: ExtractParam<typeof invitation>
+  [invitationAdmin.name]: ExtractParam<typeof invitationAdmin>
+}
+@singleton()
+class Templates implements templateHandlers {
+  [invitation.name] = invitation.template;
+  [invitationAdmin.name] = invitationAdmin.template
+}
+
+export default Templates

--- a/src/models/emailService/templates/invitation.tsx
+++ b/src/models/emailService/templates/invitation.tsx
@@ -1,0 +1,22 @@
+import Html from '@kitajs/html'
+import { SendMailOptions } from 'nodemailer'
+
+import { Env } from '../../../env.js'
+
+export default {
+  name: 'connection_invite' as const,
+  template: async function (env: Env, params: { to: string; invite: string }): Promise<SendMailOptions> {
+    return {
+      to: params.to,
+      from: env.get('EMAIL_FROM_ADDRESS'),
+      subject: 'Veritable invite',
+      text: params.invite,
+      html: await (
+        <>
+          <h1>This is an invite to connect to Veritable</h1>
+          <p>{Html.escapeHtml(params.invite)}</p>
+        </>
+      ),
+    }
+  },
+}

--- a/src/models/emailService/templates/invitationAdmin.tsx
+++ b/src/models/emailService/templates/invitationAdmin.tsx
@@ -1,0 +1,28 @@
+import Html from '@kitajs/html'
+import { SendMailOptions } from 'nodemailer'
+import { Env } from '../../../env.js'
+
+export default {
+  name: 'connection_invite_admin' as const,
+  template: async function (env: Env, params: { to: string; pin: string; address: String }): Promise<SendMailOptions> {
+    return {
+      to: params.to,
+      from: env.get('EMAIL_FROM_ADDRESS'),
+      subject: 'Action required: process veritable invitation',
+      text: `
+        Action required: process veritable invitation    
+        PIN: ${params.pin},
+        Address: ${params.address},
+      `,
+      html: await (
+        <>
+          <h1>Action required: process veritable invitation</h1>
+          <p>Pin:</p>
+          <p>{Html.escapeHtml(params.pin)}</p>
+          <p>Address:</p>
+          <p>{Html.escapeHtml(params.address)}</p>
+        </>
+      ),
+    }
+  },
+}


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Feature

## Linked tickets

[VR-101](https://digicatapult.atlassian.net/browse/VR-101)

## High level description

Implements an email sending service with support for email templating

## Detailed description

For the email sending functionality I wanted to make sure that whatever pattern we adopt we can rely on infered types to make sure that the correct parameters for the template are passed through. I also realised we needed to pass through the environment to the templates so certain settings can be rendered in. Because of this the type are a bit messy but quite effective.

## Describe alternatives you've considered

N/A - implemented as described in ticket

## Operational impact

None, all new envs have defaults and the actual code isn't used yet.

## Additional context

N/A


[VR-101]: https://digicatapult.atlassian.net/browse/VR-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ