### PR TITLE
Add init script for initialising issuance dids, schemas and credential definitions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,20 +48,13 @@ services:
         condition: service_healthy
     ports:
       - 3100:3000
-    command: --inbound-transport http 5002 ws 5003 --outbound-transport http ws
+    env_file:
+      - docker/cloudagent.env
     environment:
-      # - AFJ_REST_INBOUND_TRANSPORT="http 5002 ws 5003"
-      # - AFJ_REST_OUTBOUND_TRANSPORT="http ws"
-      - AFJ_REST_ENDPOINT=ws://veritable-cloudagent-alice:5003
-      - AFJ_REST_ADMIN_PORT=3000
-      - AFJ_REST_IPFS_ORIGIN=http://ipfs:5001
-      - AFJ_REST_POSTGRES_HOST=postgres-veritable-cloudagent-alice
-      - AFJ_REST_POSTGRES_PORT=5432
-      - AFJ_REST_POSTGRES_USERNAME=postgres
-      - AFJ_REST_POSTGRES_PASSWORD=postgres
-      - AFJ_REST_LABEL=vertiable-cloudagent
-      - AFJ_REST_WALLET_ID=alice
-      - AFJ_REST_WALLET_KEY=alice-key
+      - ENDPOINT=ws://veritable-cloudagent-alice:5003
+      - POSTGRES_HOST=postgres-veritable-cloudagent-alice
+      - WALLET_ID=alice
+      - WALLET_KEY=alice-key
 
   # -------------------- bob -------------------------------#
   veritable-ui-bob:
@@ -99,6 +92,9 @@ services:
       - IDP_INTERNAL_URL_PREFIX=http://keycloak:8080/realms/veritable/protocol/openid-connect
       - INVITATION_FROM_COMPANY_NUMBER=07964699
       - INVITATION_PIN_SECRET=secret
+      - ISSUANCE_DID_POLICY=EXISTING_OR_NEW
+      - ISSUANCE_SCHEMA_POLICY=EXISTING_OR_NEW
+      - ISSUANCE_CRED_DEF_POLICY=EXISTING_OR_NEW
   postgres-veritable-ui-bob:
     image: postgres:16.3-alpine
     container_name: postgres-veritable-ui-bob
@@ -127,20 +123,13 @@ services:
         condition: service_healthy
     ports:
       - 3101:3000
-    command: --inbound-transport http 5002 ws 5003 --outbound-transport http ws
+    env_file:
+      - docker/cloudagent.env
     environment:
-      # - AFJ_REST_INBOUND_TRANSPORT="http 5002 ws 5003"
-      # - AFJ_REST_OUTBOUND_TRANSPORT="http ws"
-      - AFJ_REST_ENDPOINT=ws://veritable-cloudagent-bob:5003
-      - AFJ_REST_ADMIN_PORT=3000
-      - AFJ_REST_IPFS_ORIGIN=http://ipfs:5001
-      - AFJ_REST_POSTGRES_HOST=postgres-veritable-cloudagent-bob
-      - AFJ_REST_POSTGRES_PORT=5432
-      - AFJ_REST_POSTGRES_USERNAME=postgres
-      - AFJ_REST_POSTGRES_PASSWORD=postgres
-      - AFJ_REST_LABEL=vertiable-cloudagent
-      - AFJ_REST_WALLET_ID=bob
-      - AFJ_REST_WALLET_KEY=bob-key
+      - ENDPOINT=ws://veritable-cloudagent-bob:5003
+      - POSTGRES_HOST=postgres-veritable-cloudagent-bob
+      - WALLET_ID=bob
+      - WALLET_KEY=bob-key
 
 volumes:
   ipfs:

--- a/docker/cloudagent.env
+++ b/docker/cloudagent.env
@@ -1,0 +1,8 @@
+INBOUND_TRANSPORT="[{\"transport\": \"http\", \"port\": 5002}, {\"transport\": \"ws\", \"port\": 5003}]"
+OUTBOUND_TRANSPORT="http,ws"
+ADMIN_PORT=3000
+IPFS_ORIGIN=http://ipfs:5001
+POSTGRES_PORT=5432
+POSTGRES_USERNAME=postgres
+POSTGRES_PASSWORD=postgres
+LABEL=vertiable-cloudagent

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.5.5",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^0.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",
@@ -19,6 +19,8 @@
     "tsoa:build": "tsoa spec-and-routes",
     "tsoa:watch": "node --watch-path=./src ./node_modules/.bin/tsoa -- spec-and-routes",
     "dev": "npm run tsoa:watch & NODE_ENV=dev node --import=tsimp/import --watch src/index.ts | pino-colada",
+    "dev:init": "NODE_ENV=dev node --import=tsimp/import src/init.ts | pino-colada",
+    "init": "node build/init.js",
     "start": "node build/index.js",
     "db:cmd": "node --import=tsimp/import ./node_modules/.bin/knex",
     "db:migrate": "npm run db:cmd -- migrate:latest",

--- a/src/controllers/__tests__/helpers.ts
+++ b/src/controllers/__tests__/helpers.ts
@@ -2,8 +2,9 @@ import { Readable } from 'node:stream'
 import { pino } from 'pino'
 
 import { Env } from '../../env.js'
+import type { ILogger } from '../../logger.js'
 
-export const mockLogger = pino({ level: 'silent' })
+export const mockLogger: ILogger = pino({ level: 'silent' })
 
 export const mockEnv = {
   get: (name: string) => {

--- a/src/controllers/connection/__tests__/helpers.ts
+++ b/src/controllers/connection/__tests__/helpers.ts
@@ -2,6 +2,7 @@ import { Readable } from 'node:stream'
 import { pino } from 'pino'
 
 import { Env } from '../../../env.js'
+import type { ILogger } from '../../../logger.js'
 import CompanyHouseEntity from '../../../models/companyHouseEntity.js'
 import Database from '../../../models/db/index.js'
 import { ConnectionRow } from '../../../models/db/types.js'
@@ -22,7 +23,7 @@ export const withConnectionMocks = () => {
     listPage: (connections: ConnectionRow[]) =>
       templateFake('list', connections[0].company_name, connections[0].status),
   } as ConnectionTemplates
-  const mockLogger = pino({ level: 'silent' })
+  const mockLogger: ILogger = pino({ level: 'silent' })
   const dbMock = {
     get: () => Promise.resolve([{ company_name: 'foo', status: 'verified' }]),
   } as unknown as Database
@@ -35,7 +36,7 @@ export const withConnectionMocks = () => {
 }
 
 export const withNewConnectionMocks = () => {
-  const mockLogger = pino({ level: 'silent' })
+  const mockLogger: ILogger = pino({ level: 'silent' })
   const mockTransactionDb = {
     insert: () => Promise.resolve([{ id: '42' }]),
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,16 @@ import { container } from 'tsyringe'
 import { Env } from './env.js'
 import Server from './server.js'
 
-import { logger } from './logger.js'
+import { Logger, type ILogger } from './logger.js'
+import { CredentialSchema } from './models/credentialSchema.js'
 ;(async () => {
-  const { app } = await Server()
-
   const env = container.resolve(Env)
+  const logger = container.resolve<ILogger>(Logger)
+
+  const schema = container.resolve<CredentialSchema>(CredentialSchema)
+  await schema.assertIssuanceRecords()
+
+  const { app } = await Server()
 
   app.listen(env.get('PORT'), () => {
     logger.info(`htmx-tsoa listening on ${env.get('PORT')} port`)

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,55 @@
+import 'reflect-metadata'
+
+import dotenv from 'dotenv'
+import envalid from 'envalid'
+import { pino } from 'pino'
+
+import { PartialEnv, envConfig } from './env.js'
+import { type ILogger } from './logger.js'
+import { CredentialSchema } from './models/credentialSchema.js'
+import VeritableCloudagent from './models/veritableCloudagent.js'
+
+type InitConfigKeys =
+  | 'CLOUDAGENT_ADMIN_ORIGIN'
+  | 'LOG_LEVEL'
+  | 'ISSUANCE_DID_POLICY'
+  | 'ISSUANCE_SCHEMA_POLICY'
+  | 'ISSUANCE_CRED_DEF_POLICY'
+
+class InitEnv implements PartialEnv<InitConfigKeys> {
+  private values: Pick<envalid.CleanedEnv<typeof envConfig>, InitConfigKeys>
+
+  constructor() {
+    if (process.env.NODE_ENV === 'test') {
+      dotenv.config({ path: 'test/test.env' })
+    } else {
+      dotenv.config()
+    }
+
+    this.values = envalid.cleanEnv(process.env, {
+      CLOUDAGENT_ADMIN_ORIGIN: envConfig.CLOUDAGENT_ADMIN_ORIGIN,
+      LOG_LEVEL: envConfig.LOG_LEVEL,
+      ISSUANCE_DID_POLICY: envConfig.ISSUANCE_DID_POLICY,
+      ISSUANCE_SCHEMA_POLICY: envConfig.ISSUANCE_SCHEMA_POLICY,
+      ISSUANCE_CRED_DEF_POLICY: envConfig.ISSUANCE_CRED_DEF_POLICY,
+    })
+  }
+
+  get<K extends InitConfigKeys>(key: K) {
+    return this.values[key]
+  }
+}
+const env = new InitEnv()
+
+const logger: ILogger = pino(
+  {
+    name: 'veritable-ui-init',
+    timestamp: true,
+    level: env.get('LOG_LEVEL'),
+  },
+  process.stdout
+)
+const cloudagent = new VeritableCloudagent(env, logger)
+const init = new CredentialSchema(env, logger, cloudagent)
+const details = await init.assertIssuanceRecords()
+logger.info(details, 'Asserted credential issuance records with: %o', details)

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,10 +6,15 @@ import { Env } from './env.js'
 export const Logger = Symbol('Logger')
 export type ILogger = ReturnType<typeof pino>
 
+let instance: ILogger | null = null
 container.register<ILogger>(Logger, {
   useFactory: (container) => {
+    if (instance) {
+      return instance
+    }
+
     const env = container.resolve(Env)
-    return pino(
+    instance = pino(
       {
         name: 'veritable-ui',
         timestamp: true,
@@ -17,5 +22,6 @@ container.register<ILogger>(Logger, {
       },
       process.stdout
     )
+    return instance
   },
 })

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,20 +3,19 @@ import { container } from 'tsyringe'
 
 import { Env } from './env.js'
 
-const env = container.resolve(Env)
-
-export const logger = pino(
-  {
-    name: 'htmx-tsoa',
-    timestamp: true,
-    level: env.get('LOG_LEVEL'),
-  },
-  process.stdout
-)
-
 export const Logger = Symbol('Logger')
-export type ILogger = typeof logger
+export type ILogger = ReturnType<typeof pino>
 
 container.register<ILogger>(Logger, {
-  useValue: logger,
+  useFactory: (container) => {
+    const env = container.resolve(Env)
+    return pino(
+      {
+        name: 'veritable-ui',
+        timestamp: true,
+        level: env.get('LOG_LEVEL'),
+      },
+      process.stdout
+    )
+  },
 })

--- a/src/models/__tests__/credentialSchema.test.ts
+++ b/src/models/__tests__/credentialSchema.test.ts
@@ -1,0 +1,482 @@
+import { expect } from 'chai'
+import { describe, test } from 'mocha'
+
+import { CredentialSchema } from '../credentialSchema.js'
+import { makeCredentialSchemaMocks } from './helpers/credentialSchemaMocks.js'
+
+describe('credentialSchema', function () {
+  describe('assertIssuanceRecords', function () {
+    describe('did assertions', function () {
+      test('policy = CREATE_NEW, has existing = false', async function () {
+        const {
+          args,
+          mockCloudagent: { createDid, getCreatedDids },
+        } = makeCredentialSchemaMocks({ didPolicy: 'CREATE_NEW', hasDids: false })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedDids.callCount).to.equal(0)
+        expect(createDid.callCount).to.equal(1)
+        expect(createDid.firstCall.args).deep.equal(['key', { keyType: 'ed25519' }])
+      })
+
+      test('policy = CREATE_NEW, has existing = true', async function () {
+        const {
+          args,
+          mockCloudagent: { createDid, getCreatedDids },
+        } = makeCredentialSchemaMocks({ didPolicy: 'CREATE_NEW', hasDids: true })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedDids.callCount).to.equal(0)
+        expect(createDid.callCount).to.equal(1)
+        expect(createDid.firstCall.args).deep.equal(['key', { keyType: 'ed25519' }])
+      })
+
+      test('policy = FIND_EXISTING, has existing = false', async function () {
+        const {
+          args,
+          mockCloudagent: { createDid, getCreatedDids },
+        } = makeCredentialSchemaMocks({ didPolicy: 'FIND_EXISTING', hasDids: false })
+        const credentialSchema = new CredentialSchema(...args)
+
+        let error: unknown | null = null
+        try {
+          await credentialSchema.assertIssuanceRecords()
+        } catch (err) {
+          error = err
+        }
+
+        expect(error).instanceOf(Error)
+        expect(getCreatedDids.callCount).to.equal(1)
+        expect(getCreatedDids.firstCall.args).deep.equal([{ method: 'key' }])
+        expect(createDid.callCount).to.equal(0)
+      })
+
+      test('policy = FIND_EXISTING, has existing = false', async function () {
+        const {
+          args,
+          mockCloudagent: { createDid, getCreatedDids },
+        } = makeCredentialSchemaMocks({ didPolicy: 'FIND_EXISTING', hasDids: true })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedDids.callCount).to.equal(1)
+        expect(getCreatedDids.firstCall.args).deep.equal([{ method: 'key' }])
+        expect(createDid.callCount).to.equal(0)
+      })
+
+      test('policy = EXISTING_OR_NEW, has existing = true', async function () {
+        const {
+          args,
+          mockCloudagent: { createDid, getCreatedDids },
+        } = makeCredentialSchemaMocks({ didPolicy: 'EXISTING_OR_NEW', hasDids: true })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedDids.callCount).to.equal(1)
+        expect(getCreatedDids.firstCall.args).deep.equal([{ method: 'key' }])
+        expect(createDid.callCount).to.equal(0)
+      })
+
+      test('policy = EXISTING_OR_NEW, has existing = false', async function () {
+        const {
+          args,
+          mockCloudagent: { createDid, getCreatedDids },
+        } = makeCredentialSchemaMocks({ didPolicy: 'EXISTING_OR_NEW', hasDids: false })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedDids.callCount).to.equal(1)
+        expect(getCreatedDids.firstCall.args).deep.equal([{ method: 'key' }])
+        expect(createDid.callCount).to.equal(1)
+        expect(createDid.firstCall.args).deep.equal(['key', { keyType: 'ed25519' }])
+      })
+    })
+
+    describe('schema assertions', function () {
+      test('policy = CREATE_NEW, has existing = false', async function () {
+        const {
+          args,
+          mockCloudagent: { createSchema, getCreatedSchemas },
+        } = makeCredentialSchemaMocks({ schemaPolicy: 'CREATE_NEW', hasSchema: false })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedSchemas.callCount).to.equal(0)
+        expect(createSchema.callCount).to.equal(1)
+        expect(createSchema.firstCall.args).deep.equal([
+          'did-id',
+          'COMPANY_DETAILS',
+          '1.0.0',
+          ['company_number', 'company_name'],
+        ])
+      })
+
+      test('policy = CREATE_NEW, has existing = true', async function () {
+        const {
+          args,
+          mockCloudagent: { createSchema, getCreatedSchemas },
+        } = makeCredentialSchemaMocks({ schemaPolicy: 'CREATE_NEW', hasSchema: true })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedSchemas.callCount).to.equal(0)
+        expect(createSchema.callCount).to.equal(1)
+        expect(createSchema.firstCall.args).deep.equal([
+          'did-id',
+          'COMPANY_DETAILS',
+          '1.0.0',
+          ['company_number', 'company_name'],
+        ])
+      })
+
+      test('policy = FIND_EXISTING, has existing = false', async function () {
+        const {
+          args,
+          mockCloudagent: { createSchema, getCreatedSchemas },
+        } = makeCredentialSchemaMocks({ schemaPolicy: 'FIND_EXISTING', hasSchema: false })
+        const credentialSchema = new CredentialSchema(...args)
+
+        let error: unknown | null = null
+        try {
+          await credentialSchema.assertIssuanceRecords()
+        } catch (err) {
+          error = err
+        }
+
+        expect(error).instanceOf(Error)
+        expect(getCreatedSchemas.callCount).to.equal(1)
+        expect(getCreatedSchemas.firstCall.args).deep.equal([
+          {
+            issuerId: 'did-id',
+            schemaName: 'COMPANY_DETAILS',
+            schemaVersion: '1.0.0',
+          },
+        ])
+        expect(createSchema.callCount).to.equal(0)
+      })
+
+      test('policy = FIND_EXISTING, has existing = false', async function () {
+        const {
+          args,
+          mockCloudagent: { createSchema, getCreatedSchemas },
+        } = makeCredentialSchemaMocks({ schemaPolicy: 'FIND_EXISTING', hasSchema: true })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedSchemas.callCount).to.equal(1)
+        expect(getCreatedSchemas.firstCall.args).deep.equal([
+          {
+            issuerId: 'did-id',
+            schemaName: 'COMPANY_DETAILS',
+            schemaVersion: '1.0.0',
+          },
+        ])
+        expect(createSchema.callCount).to.equal(0)
+      })
+
+      test('policy = EXISTING_OR_NEW, has existing = true', async function () {
+        const {
+          args,
+          mockCloudagent: { createSchema, getCreatedSchemas },
+        } = makeCredentialSchemaMocks({ schemaPolicy: 'EXISTING_OR_NEW', hasSchema: true })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedSchemas.callCount).to.equal(1)
+        expect(getCreatedSchemas.firstCall.args).deep.equal([
+          {
+            issuerId: 'did-id',
+            schemaName: 'COMPANY_DETAILS',
+            schemaVersion: '1.0.0',
+          },
+        ])
+        expect(createSchema.callCount).to.equal(0)
+      })
+
+      test('policy = EXISTING_OR_NEW, has existing = false', async function () {
+        const {
+          args,
+          mockCloudagent: { createSchema, getCreatedSchemas },
+        } = makeCredentialSchemaMocks({ schemaPolicy: 'EXISTING_OR_NEW', hasSchema: false })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedSchemas.callCount).to.equal(1)
+        expect(getCreatedSchemas.firstCall.args).deep.equal([
+          {
+            issuerId: 'did-id',
+            schemaName: 'COMPANY_DETAILS',
+            schemaVersion: '1.0.0',
+          },
+        ])
+        expect(createSchema.callCount).to.equal(1)
+        expect(createSchema.firstCall.args).deep.equal([
+          'did-id',
+          'COMPANY_DETAILS',
+          '1.0.0',
+          ['company_number', 'company_name'],
+        ])
+      })
+    })
+
+    describe('credential definition assertions', function () {
+      test('policy = CREATE_NEW, has existing = false', async function () {
+        const {
+          args,
+          mockCloudagent: { createCredentialDefinition, getCreatedCredentialDefinitions },
+        } = makeCredentialSchemaMocks({ credDefPolicy: 'CREATE_NEW', hasCredDef: false })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedCredentialDefinitions.callCount).to.equal(0)
+        expect(createCredentialDefinition.callCount).to.equal(1)
+        expect(createCredentialDefinition.firstCall.args).deep.equal(['did-id', 'id', 'company_details_v1.0.0'])
+      })
+
+      test('policy = CREATE_NEW, has existing = true', async function () {
+        const {
+          args,
+          mockCloudagent: { createCredentialDefinition, getCreatedCredentialDefinitions },
+        } = makeCredentialSchemaMocks({ credDefPolicy: 'CREATE_NEW', hasCredDef: true })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedCredentialDefinitions.callCount).to.equal(0)
+        expect(createCredentialDefinition.callCount).to.equal(1)
+        expect(createCredentialDefinition.firstCall.args).deep.equal(['did-id', 'id', 'company_details_v1.0.0'])
+      })
+
+      test('policy = FIND_EXISTING, has existing = false', async function () {
+        const {
+          args,
+          mockCloudagent: { createCredentialDefinition, getCreatedCredentialDefinitions },
+        } = makeCredentialSchemaMocks({ credDefPolicy: 'FIND_EXISTING', hasCredDef: false })
+        const credentialSchema = new CredentialSchema(...args)
+
+        let error: unknown | null = null
+        try {
+          await credentialSchema.assertIssuanceRecords()
+        } catch (err) {
+          error = err
+        }
+
+        expect(error).instanceOf(Error)
+        expect(getCreatedCredentialDefinitions.callCount).to.equal(1)
+        expect(getCreatedCredentialDefinitions.firstCall.args).deep.equal([
+          {
+            issuerId: 'did-id',
+            schemaId: 'id',
+          },
+        ])
+        expect(createCredentialDefinition.callCount).to.equal(0)
+      })
+
+      test('policy = FIND_EXISTING, has existing = false', async function () {
+        const {
+          args,
+          mockCloudagent: { createCredentialDefinition, getCreatedCredentialDefinitions },
+        } = makeCredentialSchemaMocks({ credDefPolicy: 'FIND_EXISTING', hasCredDef: true })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedCredentialDefinitions.callCount).to.equal(1)
+        expect(getCreatedCredentialDefinitions.firstCall.args).deep.equal([
+          {
+            issuerId: 'did-id',
+            schemaId: 'id',
+          },
+        ])
+        expect(createCredentialDefinition.callCount).to.equal(0)
+      })
+
+      test('policy = EXISTING_OR_NEW, has existing = true', async function () {
+        const {
+          args,
+          mockCloudagent: { createCredentialDefinition, getCreatedCredentialDefinitions },
+        } = makeCredentialSchemaMocks({ credDefPolicy: 'EXISTING_OR_NEW', hasCredDef: true })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedCredentialDefinitions.callCount).to.equal(1)
+        expect(getCreatedCredentialDefinitions.firstCall.args).deep.equal([
+          {
+            issuerId: 'did-id',
+            schemaId: 'id',
+          },
+        ])
+        expect(createCredentialDefinition.callCount).to.equal(0)
+      })
+
+      test('policy = EXISTING_OR_NEW, has existing = false', async function () {
+        const {
+          args,
+          mockCloudagent: { createCredentialDefinition, getCreatedCredentialDefinitions },
+        } = makeCredentialSchemaMocks({ credDefPolicy: 'EXISTING_OR_NEW', hasCredDef: false })
+        const credentialSchema = new CredentialSchema(...args)
+
+        const result = await credentialSchema.assertIssuanceRecords()
+
+        expect(result).to.deep.equal({
+          credentialDefinitionId: {
+            COMPANY_DETAILS: 'id',
+          },
+          issuerId: 'did-id',
+          schemaId: {
+            COMPANY_DETAILS: 'id',
+          },
+        })
+        expect(getCreatedCredentialDefinitions.callCount).to.equal(1)
+        expect(getCreatedCredentialDefinitions.firstCall.args).deep.equal([
+          {
+            issuerId: 'did-id',
+            schemaId: 'id',
+          },
+        ])
+        expect(createCredentialDefinition.callCount).to.equal(1)
+        expect(createCredentialDefinition.firstCall.args).deep.equal(['did-id', 'id', 'company_details_v1.0.0'])
+      })
+    })
+  })
+})

--- a/src/models/__tests__/fixtures/cloudagentFixtures.ts
+++ b/src/models/__tests__/fixtures/cloudagentFixtures.ts
@@ -1,5 +1,7 @@
 import { pino } from 'pino'
 
+import type { ILogger } from '../../../logger.js'
+
 export const createInviteSuccessResponse = {
   invitationUrl: 'example.com',
   outOfBandRecord: { id: 'example-id' },
@@ -22,6 +24,26 @@ export const getConnectionsSuccessResponse = [
   },
 ]
 
+export const createDidResponse = {
+  didDocument: {
+    id: 'did-id',
+  },
+}
+
+export const createSchemaResponse = {
+  id: 'id',
+  issuerId: 'issuerId',
+  name: 'name',
+  version: 'version',
+  attrNames: ['attrName'],
+}
+
+export const createCredentialDefinitionResponse = {
+  id: 'id',
+  issuerId: 'issuerId',
+  schemaId: 'schemaId',
+}
+
 export const invalidResponse = {}
 
-export const mockLogger = pino({ level: 'silent' })
+export const mockLogger: ILogger = pino({ level: 'silent' })

--- a/src/models/__tests__/helpers/credentialSchemaMocks.ts
+++ b/src/models/__tests__/helpers/credentialSchemaMocks.ts
@@ -1,0 +1,65 @@
+import { pino } from 'pino'
+import sinon from 'sinon'
+
+import { Env } from '../../../env.js'
+import { ILogger } from '../../../logger.js'
+import VeritableCloudagent from '../../veritableCloudagent.js'
+import {
+  createCredentialDefinitionResponse,
+  createDidResponse,
+  createSchemaResponse,
+} from '../fixtures/cloudagentFixtures.js'
+
+type MockOptions = {
+  hasDids: boolean
+  hasSchema: boolean
+  hasCredDef: boolean
+  didPolicy: string
+  schemaPolicy: string
+  credDefPolicy: string
+}
+const defaultMockOptions: MockOptions = {
+  hasDids: true,
+  hasSchema: true,
+  hasCredDef: true,
+  didPolicy: 'FIND_EXISTING',
+  schemaPolicy: 'FIND_EXISTING',
+  credDefPolicy: 'FIND_EXISTING',
+}
+
+export const makeCredentialSchemaMocks = (options: Partial<MockOptions>) => {
+  const mergedOptions = Object.assign({}, defaultMockOptions, options)
+
+  const mockLogger: ILogger = pino({ level: 'silent' })
+  const mockEnv = {
+    get: (name: string) => {
+      switch (name) {
+        case 'ISSUANCE_DID_POLICY':
+          return mergedOptions.didPolicy
+        case 'ISSUANCE_SCHEMA_POLICY':
+          return mergedOptions.schemaPolicy
+        case 'ISSUANCE_CRED_DEF_POLICY':
+          return mergedOptions.credDefPolicy
+        default:
+          throw new Error()
+      }
+    },
+  } as unknown as Env
+  const mockCloudagent = {
+    getCreatedDids: sinon.stub().resolves(mergedOptions.hasDids ? [createDidResponse.didDocument] : []),
+    createDid: sinon.stub().resolves(createDidResponse.didDocument),
+    getCreatedSchemas: sinon.stub().resolves(mergedOptions.hasSchema ? [createSchemaResponse] : []),
+    createSchema: sinon.stub().resolves(createSchemaResponse),
+    getCreatedCredentialDefinitions: sinon
+      .stub()
+      .resolves(mergedOptions.hasCredDef ? [createCredentialDefinitionResponse] : []),
+    createCredentialDefinition: sinon.stub().resolves(createCredentialDefinitionResponse),
+  }
+
+  return {
+    mockEnv,
+    mockLogger,
+    mockCloudagent,
+    args: [mockEnv, mockLogger, mockCloudagent as unknown as VeritableCloudagent] as const,
+  }
+}

--- a/src/models/__tests__/idpService.test.ts
+++ b/src/models/__tests__/idpService.test.ts
@@ -5,6 +5,7 @@ import { MockAgent, getGlobalDispatcher, setGlobalDispatcher } from 'undici'
 import { pino } from 'pino'
 import { Env } from '../../env.js'
 import { ForbiddenError } from '../../errors.js'
+import type { ILogger } from '../../logger.js'
 import IDPService from '../idpService.js'
 
 const mockEnv: Env = {
@@ -20,7 +21,7 @@ const mockEnv: Env = {
   },
 } as Env
 
-const mockLogger = pino({ level: 'silent' })
+const mockLogger: ILogger = pino({ level: 'silent' })
 
 const mockTokenResponse = {
   access_token: 'access',

--- a/src/models/__tests__/veritableCloudagent.test.ts
+++ b/src/models/__tests__/veritableCloudagent.test.ts
@@ -2,7 +2,10 @@ import { describe, it } from 'mocha'
 
 import { Env } from '../../env.js'
 import {
+  createCredentialDefinitionResponse,
+  createDidResponse,
   createInviteSuccessResponse,
+  createSchemaResponse,
   getConnectionsSuccessResponse,
   invalidResponse,
   mockLogger,
@@ -191,6 +194,333 @@ describe('veritableCloudagent', () => {
         let error: unknown = null
         try {
           await cloudagent.deleteConnection('42')
+        } catch (err) {
+          error = err
+        }
+        expect(error).instanceOf(InternalError)
+      })
+    })
+  })
+
+  describe('createDid', () => {
+    describe('success', function () {
+      withCloudagentMock('POST', `/v1/dids/create`, 200, createDidResponse)
+
+      it('should give back did', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+        const response = await cloudagent.createDid('key', { keyType: 'ed25519' })
+        expect(response).deep.equal(createDidResponse.didDocument)
+      })
+    })
+
+    describe('error (response code)', function () {
+      withCloudagentMock('POST', `/v1/dids/create`, 400, {})
+
+      it('should throw internal error', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+
+        let error: unknown = null
+        try {
+          await cloudagent.createDid('key', { keyType: 'ed25519' })
+        } catch (err) {
+          error = err
+        }
+        expect(error).instanceOf(InternalError)
+      })
+    })
+
+    describe('error (response invalid)', function () {
+      withCloudagentMock('POST', `/v1/dids/create`, 200, invalidResponse)
+
+      it('should throw internal error', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+
+        let error: unknown = null
+        try {
+          await cloudagent.createDid('key', { keyType: 'ed25519' })
+        } catch (err) {
+          error = err
+        }
+        expect(error).instanceOf(InternalError)
+      })
+    })
+  })
+
+  describe('getCreatedDids', () => {
+    describe('success', function () {
+      withCloudagentMock('GET', `/v1/dids?createdLocally=true&method=key`, 200, [createDidResponse])
+
+      it('should give back did', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+        const response = await cloudagent.getCreatedDids({ method: 'key' })
+        expect(response).deep.equal([createDidResponse.didDocument])
+      })
+    })
+
+    describe('error (response code)', function () {
+      withCloudagentMock('GET', `/v1/dids?createdLocally=true&method=key`, 400, {})
+
+      it('should throw internal error', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+
+        let error: unknown = null
+        try {
+          await cloudagent.getCreatedDids({ method: 'key' })
+        } catch (err) {
+          error = err
+        }
+        expect(error).instanceOf(InternalError)
+      })
+    })
+
+    describe('error (response invalid)', function () {
+      withCloudagentMock('GET', `/v1/dids?createdLocally=true&method=key`, 200, invalidResponse)
+
+      it('should throw internal error', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+
+        let error: unknown = null
+        try {
+          await cloudagent.getCreatedDids({ method: 'key' })
+        } catch (err) {
+          error = err
+        }
+        expect(error).instanceOf(InternalError)
+      })
+    })
+  })
+
+  describe('createSchema', () => {
+    describe('success', function () {
+      withCloudagentMock('POST', `/v1/schemas`, 200, createSchemaResponse)
+
+      it('should give back schema', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+        const response = await cloudagent.createSchema('issuerId', 'name', 'version', [])
+        expect(response).deep.equal(createSchemaResponse)
+      })
+    })
+
+    describe('error (response code)', function () {
+      withCloudagentMock('POST', `/v1/schemas`, 400, {})
+
+      it('should throw internal error', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+
+        let error: unknown = null
+        try {
+          await cloudagent.createSchema('issuerId', 'name', 'version', [])
+        } catch (err) {
+          error = err
+        }
+        expect(error).instanceOf(InternalError)
+      })
+    })
+
+    describe('error (response invalid)', function () {
+      withCloudagentMock('POST', `/v1/schemas`, 200, invalidResponse)
+
+      it('should throw internal error', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+
+        let error: unknown = null
+        try {
+          await cloudagent.createSchema('issuerId', 'name', 'version', [])
+        } catch (err) {
+          error = err
+        }
+        expect(error).instanceOf(InternalError)
+      })
+    })
+  })
+
+  describe('getCreatedSchemas', () => {
+    describe('success', function () {
+      withCloudagentMock(
+        'GET',
+        `/v1/schemas?createdLocally=true&issuerId=issuerId&schemaName=name&schemaVersion=version`,
+        200,
+        [createSchemaResponse]
+      )
+
+      it('should give back schema', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+        const response = await cloudagent.getCreatedSchemas({
+          issuerId: 'issuerId',
+          schemaName: 'name',
+          schemaVersion: 'version',
+        })
+        expect(response).deep.equal([createSchemaResponse])
+      })
+    })
+
+    describe('error (response code)', function () {
+      withCloudagentMock(
+        'GET',
+        `/v1/schemas?createdLocally=true&issuerId=issuerId&schemaName=name&schemaVersion=version`,
+        400,
+        {}
+      )
+
+      it('should throw internal error', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+
+        let error: unknown = null
+        try {
+          await cloudagent.getCreatedSchemas({ issuerId: 'issuerId', schemaName: 'name', schemaVersion: 'version' })
+        } catch (err) {
+          error = err
+        }
+        expect(error).instanceOf(InternalError)
+      })
+    })
+
+    describe('error (response invalid)', function () {
+      withCloudagentMock(
+        'GET',
+        `/v1/schemas?createdLocally=true&issuerId=issuerId&schemaName=name&schemaVersion=version`,
+        200,
+        invalidResponse
+      )
+
+      it('should throw internal error', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+
+        let error: unknown = null
+        try {
+          await cloudagent.getCreatedSchemas({ issuerId: 'issuerId', schemaName: 'name', schemaVersion: 'version' })
+        } catch (err) {
+          error = err
+        }
+        expect(error).instanceOf(InternalError)
+      })
+    })
+  })
+
+  //HERE
+
+  describe('createCredentialDefinition', () => {
+    describe('success', function () {
+      withCloudagentMock('POST', `/v1/credential-definitions`, 200, createCredentialDefinitionResponse)
+
+      it('should give back credential definition', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+        const response = await cloudagent.createCredentialDefinition('issuerId', 'schemaId', 'tag')
+        expect(response).deep.equal(createCredentialDefinitionResponse)
+      })
+    })
+
+    describe('error (response code)', function () {
+      withCloudagentMock('POST', `/v1/schemas`, 400, {})
+
+      it('should throw internal error', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+
+        let error: unknown = null
+        try {
+          await cloudagent.createCredentialDefinition('issuerId', 'schemaId', 'tag')
+        } catch (err) {
+          error = err
+        }
+        expect(error).instanceOf(InternalError)
+      })
+    })
+
+    describe('error (response invalid)', function () {
+      withCloudagentMock('POST', `/v1/schemas`, 200, invalidResponse)
+
+      it('should throw internal error', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+
+        let error: unknown = null
+        try {
+          await cloudagent.createCredentialDefinition('issuerId', 'schemaId', 'tag')
+        } catch (err) {
+          error = err
+        }
+        expect(error).instanceOf(InternalError)
+      })
+    })
+  })
+
+  describe('getCreatedCredentialDefinitions', () => {
+    describe('success', function () {
+      withCloudagentMock(
+        'GET',
+        `/v1/credential-definitions?createdLocally=true&issuerId=issuerId&schemaId=schemaId`,
+        200,
+        [createCredentialDefinitionResponse]
+      )
+
+      it('should give back credential definition', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+        const response = await cloudagent.getCreatedCredentialDefinitions({
+          issuerId: 'issuerId',
+          schemaId: 'schemaId',
+        })
+        expect(response).deep.equal([createCredentialDefinitionResponse])
+      })
+    })
+
+    describe('error (response code)', function () {
+      withCloudagentMock(
+        'GET',
+        `/v1/credential-definitions?createdLocally=true&issuerId=issuerId&schemaId=schemaId`,
+        400,
+        {}
+      )
+
+      it('should throw internal error', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+
+        let error: unknown = null
+        try {
+          await cloudagent.getCreatedCredentialDefinitions({
+            issuerId: 'issuerId',
+            schemaId: 'schemaId',
+          })
+        } catch (err) {
+          error = err
+        }
+        expect(error).instanceOf(InternalError)
+      })
+    })
+
+    describe('error (response invalid)', function () {
+      withCloudagentMock(
+        'GET',
+        `/v1/credential-definitions?createdLocally=true&issuerId=issuerId&schemaId=schemaId`,
+        200,
+        invalidResponse
+      )
+
+      it('should throw internal error', async () => {
+        const environment = new Env()
+        const cloudagent = new VeritableCloudagent(environment, mockLogger)
+
+        let error: unknown = null
+        try {
+          await cloudagent.getCreatedCredentialDefinitions({
+            issuerId: 'issuerId',
+            schemaId: 'schemaId',
+          })
         } catch (err) {
           error = err
         }

--- a/src/models/credentialSchema.ts
+++ b/src/models/credentialSchema.ts
@@ -1,0 +1,148 @@
+import { inject, injectable, singleton } from 'tsyringe'
+import { Env, type PartialEnv } from '../env.js'
+import { Logger, type ILogger } from '../logger.js'
+import VeritableCloudagent from './veritableCloudagent.js'
+
+export const schemaMap = {
+  COMPANY_DETAILS: { version: '1.0.0', attrNames: ['company_number', 'company_name'] },
+} as const
+
+type SCHEMA_NAMES = keyof typeof schemaMap
+
+@singleton()
+@injectable()
+export class CredentialSchema {
+  private issuerId?: string
+  private schemaId?: Record<SCHEMA_NAMES, string>
+  private credentialDefinitionId?: Record<SCHEMA_NAMES, string>
+
+  constructor(
+    @inject(Env) private env: PartialEnv<'ISSUANCE_DID_POLICY' | 'ISSUANCE_SCHEMA_POLICY' | 'ISSUANCE_CRED_DEF_POLICY'>,
+    @inject(Logger) private logger: ILogger,
+    private cloudagent: VeritableCloudagent
+  ) {}
+
+  private async assertDid(): Promise<string> {
+    if (this.issuerId) {
+      return this.issuerId
+    }
+
+    const policy = this.env.get('ISSUANCE_DID_POLICY')
+    if (policy !== 'CREATE_NEW' && policy !== 'FIND_EXISTING' && policy !== 'EXISTING_OR_NEW') {
+      return policy
+    }
+
+    if (policy === 'FIND_EXISTING' || policy === 'EXISTING_OR_NEW') {
+      const createdDids = await this.cloudagent.getCreatedDids({ method: 'key' })
+      if (createdDids.length !== 0) {
+        return createdDids[0].id
+      }
+    }
+
+    if (policy === 'CREATE_NEW' || policy === 'EXISTING_OR_NEW') {
+      const result = await this.cloudagent.createDid('key', { keyType: 'ed25519' })
+      return result.id
+    }
+
+    throw new Error('Could not find existing DiD to use for issuing credentials')
+  }
+
+  private async assertSchema(issuerId: string, schemaName: SCHEMA_NAMES): Promise<string> {
+    if (this.schemaId) {
+      return this.schemaId[schemaName]
+    }
+
+    const policy = this.env.get('ISSUANCE_SCHEMA_POLICY')
+    if (policy !== 'CREATE_NEW' && policy !== 'FIND_EXISTING' && policy !== 'EXISTING_OR_NEW') {
+      return policy
+    }
+
+    const expectedSchema = {
+      issuerId,
+      name: schemaName,
+      version: schemaMap[schemaName].version,
+      attrNames: schemaMap[schemaName].attrNames,
+    }
+
+    if (policy === 'EXISTING_OR_NEW' || policy === 'FIND_EXISTING') {
+      const findSchema = await this.cloudagent.getCreatedSchemas({
+        issuerId,
+        schemaName: expectedSchema.name,
+        schemaVersion: expectedSchema.version,
+      })
+      if (findSchema.length !== 0) {
+        return findSchema[0].id
+      }
+    }
+
+    if (policy === 'CREATE_NEW' || policy === 'EXISTING_OR_NEW') {
+      const result = await this.cloudagent.createSchema(
+        expectedSchema.issuerId,
+        expectedSchema.name,
+        expectedSchema.version,
+        [...expectedSchema.attrNames]
+      )
+      return result.id
+    }
+
+    throw new Error(`Could not assert schema that matched schema policy ${policy}`)
+  }
+
+  private async assertCredentialDefinition(
+    issuerId: string,
+    schemaId: string,
+    schemaName: SCHEMA_NAMES
+  ): Promise<string> {
+    if (this.credentialDefinitionId) {
+      return this.credentialDefinitionId[schemaName]
+    }
+
+    const policy = this.env.get('ISSUANCE_CRED_DEF_POLICY')
+    if (policy !== 'CREATE_NEW' && policy !== 'FIND_EXISTING' && policy !== 'EXISTING_OR_NEW') {
+      return policy
+    }
+
+    if (policy === 'EXISTING_OR_NEW' || policy === 'FIND_EXISTING') {
+      const findCredDef = await this.cloudagent.getCreatedCredentialDefinitions({ schemaId, issuerId })
+      if (findCredDef.length !== 0) {
+        return findCredDef[0].id
+      }
+    }
+
+    if (policy === 'CREATE_NEW' || policy === 'EXISTING_OR_NEW') {
+      const result = await this.cloudagent.createCredentialDefinition(issuerId, schemaId, 'company_details_v1.0.0')
+      return result.id
+    }
+
+    throw new Error(`Could not assert credential definition that matched schema policy ${policy}`)
+  }
+
+  public async assertIssuanceRecords() {
+    const issuerId = await this.assertDid()
+    this.issuerId = issuerId
+
+    const schemaId = await this.assertSchema(issuerId, 'COMPANY_DETAILS')
+    this.schemaId = { COMPANY_DETAILS: schemaId }
+
+    const credentialDefinitionId = await this.assertCredentialDefinition(issuerId, schemaId, 'COMPANY_DETAILS')
+    this.credentialDefinitionId = { COMPANY_DETAILS: credentialDefinitionId }
+
+    const records = this.issuanceRecords
+    this.logger.info(
+      records,
+      'For issuing credentials using:\n\tissuerId:\t%s\n\tschemaId:\t%s\n\tcred-def:\t%s',
+      records.issuerId,
+      records.schemaId.COMPANY_DETAILS,
+      records.credentialDefinitionId.COMPANY_DETAILS
+    )
+
+    return records
+  }
+
+  get issuanceRecords() {
+    if (!this.issuerId || !this.schemaId || !this.credentialDefinitionId) {
+      throw new Error('Credential Schema records have not been initialised')
+    }
+    return { issuerId: this.issuerId, schemaId: this.schemaId, credentialDefinitionId: this.credentialDefinitionId }
+  }
+}

--- a/src/models/emailService/__tests__/index.test.ts
+++ b/src/models/emailService/__tests__/index.test.ts
@@ -6,6 +6,7 @@ import sinon from 'sinon'
 
 import { Env } from '../../../env.js'
 
+import type { ILogger } from '../../../logger.js'
 import EmailService from '../index.js'
 
 const mockEnv: Env = {
@@ -31,7 +32,7 @@ describe('EmailService', () => {
   describe('sendMail', () => {
     it('should log message details', async () => {
       const logger = mkMockLogger()
-      const emailService = new EmailService(mockEnv, mockTemplates, logger as unknown as pino.Logger)
+      const emailService = new EmailService(mockEnv, mockTemplates, logger as unknown as ILogger)
 
       await emailService.sendMail('connection_invite', { to: 'user@example.com', invite: '1234567890987654321' })
 

--- a/src/utils/__tests__/fixtures/testIndexedAsyncEventEmitter.ts
+++ b/src/utils/__tests__/fixtures/testIndexedAsyncEventEmitter.ts
@@ -1,9 +1,9 @@
 import { pino } from 'pino'
 
-import { ILogger } from '../../../logger.js'
+import type { ILogger } from '../../../logger.js'
 import IndexedAsyncEventEmitter from '../../indexedAsyncEventEmitter.js'
 
-const mockLogger = pino({ level: 'silent' })
+const mockLogger: ILogger = pino({ level: 'silent' })
 
 export type EventNames = 'A' | 'B' | 'C'
 export type EventData = {

--- a/test/helpers/cloudagent.ts
+++ b/test/helpers/cloudagent.ts
@@ -4,9 +4,10 @@ import { Env } from '../../src/env.js'
 import VeritableCloudagent from '../../src/models/veritableCloudagent.js'
 
 import { container } from 'tsyringe'
+import { type ILogger } from '../../src/logger.js'
 import { validCompanyName, validCompanyNumber } from './fixtures.js'
 
-const mockLogger = pino({ level: 'silent' })
+const mockLogger: ILogger = pino({ level: 'silent' })
 
 const cleanupShared = async function (agent: VeritableCloudagent) {
   const connections = await agent.getConnections()


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

[VR-62](https://digicatapult.atlassian.net/browse/VR-62)

## High level description

Adds init script for initialising the Did, schema and credential definition that can then be used for issuing our first credential

## Detailed description

Broken this up into a few bits:

1. Make it so `Env` can be constructed partially so that the init script doesn't need the full environment but can at least share the validation so we're consistent
2. For each of did, schema and cred def we now have a policy of what should be done on init and startup. The choices are `CREATE_NEW` which will always create new versions, `FIND_EXISTING` which will always search the cloudagent for an existing valid record and erro if it can't find one, `EXISTING_OR_NEW` which will ideally find an existing record but will create a new one if one doesn't exist and finally you can pass an `id` for a record at which point it will use that specific record. The design here was to ensure we can be flexible in what needs to happen on startup in dev, prod, testing and init
3. Implemented new method in `VertiableCloudagent` for listing and creating the various bits
4. Implemented new class `CredentialSchema` that can be used to manage what records we're using
5. Fix docker compose file after change of env format

## Describe alternatives you've considered

Considered many ways of handling the envs for issuance policy and this seemed the most explicit and therefore cleanest. Otherwsie we were making assumptions about what we want it to do.

## Operational impact

New envs need to be configured prior to this going live:

* ISSUANCE_DID_POLICY
* ISSUANCE_SCHEMA_POLICY
* ISSUANCE_CRED_DEF_POLICY

We also need to update the helm chart to do the init process

## Additional context

N/A


[VR-62]: https://digicatapult.atlassian.net/browse/VR-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ