### PR TITLE
Fix redirect loop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.8.46",
+  "version": "0.8.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.8.46",
+      "version": "0.8.47",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^0.1.38",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.8.46",
+  "version": "0.8.47",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",

--- a/public/scripts/auth-redirect.js
+++ b/public/scripts/auth-redirect.js
@@ -1,8 +1,8 @@
 window.addEventListener('load', function () {
   document.body.addEventListener('htmx:beforeSwap', function (evt) {
     if (evt.detail.xhr.status === 401) {
-      // when a 401 occurs redirect to login and then back to this page
-      window.location.replace('/auth/login?' + new URLSearchParams({ path: window.location.toString() }).toString())
+      // when a 401 occurs reload the page so we can redirect to login
+      window.location.reload()
     }
   })
 })

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -56,19 +56,22 @@ export class AuthController extends HTMLController {
       throw new InternalError()
     }
 
-    // make random state
+    // make random state. We use a cookie suffix so we can handle multiple simultaneous pages on the same site
+    const cookieSuffix = randomBytes(16).toString('base64url')
     const nonce = randomBytes(32).toString('base64url')
-    res.cookie('VERITABLE_NONCE', nonce, nonceCookieOpts)
+    res.cookie(`VERITABLE_NONCE.${cookieSuffix}`, nonce, nonceCookieOpts)
 
-    // setup for final redirect
-    res.cookie('VERITABLE_REDIRECT', path, nonceCookieOpts)
+    // setup for final redirect. We also check if we're in a redirect loop where we'll redirect back to the redirect. If so just go to root
+    const parsedPath = new URL(path, this.env.get('PUBLIC_URL'))
+    const veritableRedirect = parsedPath.pathname === '/auth/redirect' ? this.env.get('PUBLIC_URL') : path
+    res.cookie(`VERITABLE_REDIRECT.${cookieSuffix}`, veritableRedirect, nonceCookieOpts)
 
     const redirect = new URL(this.idp.authorizationEndpoint('PUBLIC'))
     redirect.search = new URLSearchParams({
       response_type: 'code',
       client_id: this.env.get('IDP_CLIENT_ID'),
       redirect_uri: this.redirectUrl,
-      state: nonce,
+      state: `${cookieSuffix}.${nonce}`,
       scope: 'openid',
     }).toString()
 
@@ -79,25 +82,30 @@ export class AuthController extends HTMLController {
   @Get('/redirect')
   @SuccessResponse(302, 'Redirect')
   public async redirect(@Request() req: express.Request, @Query() state: string, @Query() code: string): Promise<void> {
-    const {
-      res,
-      signedCookies: { VERITABLE_NONCE, VERITABLE_REDIRECT },
-    } = req
+    const { res } = req
     if (!res) {
       throw new InternalError()
     }
-    if (state !== VERITABLE_NONCE) {
-      throw new ForbiddenError()
+    const [cookieSuffix, redirectNonce] = state.split('.')
+    if (!cookieSuffix || !redirectNonce) {
+      throw new ForbiddenError('Format of state parameter incorrect')
+    }
+
+    const { [`VERITABLE_NONCE.${cookieSuffix}`]: cookieNonce, [`VERITABLE_REDIRECT.${cookieSuffix}`]: cookieRedirect } =
+      req.signedCookies
+
+    if (redirectNonce !== cookieNonce) {
+      throw new ForbiddenError('State parameter did not match expected nonce')
     }
 
     const { access_token, refresh_token } = await this.idp.getTokenFromCode(code, this.redirectUrl)
 
-    res.clearCookie('VERITABLE_NONCE')
-    res.clearCookie('VERITABLE_REDIRECT')
+    res.clearCookie(`VERITABLE_NONCE.${cookieSuffix}`)
+    res.clearCookie(`VERITABLE_REDIRECT.${cookieSuffix}`)
     res.cookie('VERITABLE_ACCESS_TOKEN', access_token, tokenCookieOpts)
     res.cookie('VERITABLE_REFRESH_TOKEN', refresh_token, tokenCookieOpts)
 
-    const redirect = VERITABLE_REDIRECT || `${this.env.get('PUBLIC_URL')}`
+    const redirect = cookieRedirect || `${this.env.get('PUBLIC_URL')}`
 
     this.logger.debug('auth redirect to %s', redirect)
     res.redirect(302, redirect)

--- a/src/controllers/__tests__/auth.test.ts
+++ b/src/controllers/__tests__/auth.test.ts
@@ -250,5 +250,23 @@ describe('AuthController', () => {
       expect(stub.calledOnce).equal(true)
       expect(stub.firstCall.args).deep.equal([302, 'http://www.example.com'])
     })
+
+    it('should redirect to without setting cookies on error', async function () {
+      const controller = new AuthController(mockEnv, idpMock, mockLogger)
+      const req = mkRequestMock()
+
+      await controller.redirect(
+        { ...req, signedCookies: { 'VERITABLE_NONCE.suffix': 'nonce' } } as unknown as express.Request,
+        'suffix.nonce',
+        undefined,
+        'error'
+      )
+
+      const stub = req.res.redirect
+      expect(stub.calledOnce).equal(true)
+      expect(stub.firstCall.args).deep.equal([302, 'http://www.example.com'])
+      expect(req.res.cookie.callCount).to.equal(0)
+      expect(req.res.clearCookie.callCount).to.equal(0)
+    })
   })
 })

--- a/src/controllers/__tests__/auth.test.ts
+++ b/src/controllers/__tests__/auth.test.ts
@@ -26,7 +26,7 @@ const mkRequestMock = () => ({
     cookie: sinon.stub(),
     redirect: sinon.stub(),
   },
-  signedCookies: { VERITABLE_NONCE: 'nonce', VERITABLE_REDIRECT: '/example' },
+  signedCookies: { 'VERITABLE_NONCE.suffix': 'nonce', 'VERITABLE_REDIRECT.suffix': '/example' },
 })
 
 describe('AuthController', () => {
@@ -65,7 +65,7 @@ describe('AuthController', () => {
       await controller.login(req as unknown as express.Request, '/example')
 
       const stub = req.res.cookie
-      expect(stub.firstCall.args[0]).to.equal('VERITABLE_NONCE')
+      expect(stub.firstCall.args[0]).to.match(/^VERITABLE_NONCE\.[a-zA-Z0-9_-]+/)
       expect(typeof stub.firstCall.args[1]).to.equal('string')
       expect(stub.firstCall.args[2]).to.deep.equal({
         sameSite: true,
@@ -83,8 +83,26 @@ describe('AuthController', () => {
       await controller.login(req as unknown as express.Request, '/example')
 
       const stub = req.res.cookie
-      expect(stub.secondCall.args[0]).to.equal('VERITABLE_REDIRECT')
+      expect(stub.secondCall.args[0]).to.match(/^VERITABLE_REDIRECT\.[a-zA-Z0-9_-]+/)
       expect(stub.secondCall.args[1]).to.equal('/example')
+      expect(stub.secondCall.args[2]).to.deep.equal({
+        sameSite: true,
+        httpOnly: true,
+        signed: true,
+        secure: true,
+        path: '/auth/redirect',
+      })
+    })
+
+    it('should set redirect cookie to # if in redirect loop', async () => {
+      const controller = new AuthController(mockEnv, idpMock, mockLogger)
+      const req = mkRequestMock()
+
+      await controller.login(req as unknown as express.Request, '/auth/redirect?foo=bar')
+
+      const stub = req.res.cookie
+      expect(stub.secondCall.args[0]).to.match(/^VERITABLE_REDIRECT\.[a-zA-Z0-9_-]+/)
+      expect(stub.secondCall.args[1]).to.equal('http://www.example.com')
       expect(stub.secondCall.args[2]).to.deep.equal({
         sameSite: true,
         httpOnly: true,
@@ -102,20 +120,22 @@ describe('AuthController', () => {
 
       // get the nonce that was generated
       const cookieStub = req.res.cookie
+      const prefix = cookieStub.firstCall.args[0].split('.')[1]
       const nonce = cookieStub.firstCall.args[1]
-      const expectedUrl = new URL('http://public.example.com/auth')
-      expectedUrl.search = new URLSearchParams({
-        response_type: 'code',
-        client_id: 'veritable-ui',
-        redirect_uri: 'http://www.example.com/auth/redirect',
-        state: nonce,
-        scope: 'openid',
-      }).toString()
 
       const stub = req.res.redirect
       expect(stub.calledOnce).to.equal(true)
       expect(stub.firstCall.args[0]).to.equal(302)
-      expect(stub.firstCall.args[1]).to.equal(expectedUrl.toString())
+
+      const redirectUrl = new URL(stub.firstCall.args[1])
+      expect(redirectUrl.protocol).to.equal('http:')
+      expect(redirectUrl.hostname).to.equal('public.example.com')
+      expect(redirectUrl.pathname).to.equal('/auth')
+      expect(redirectUrl.searchParams.get('response_type')).to.equal('code')
+      expect(redirectUrl.searchParams.get('client_id')).to.equal('veritable-ui')
+      expect(redirectUrl.searchParams.get('redirect_uri')).to.equal('http://www.example.com/auth/redirect')
+      expect(redirectUrl.searchParams.get('state')).to.equal(`${prefix}.${nonce}`)
+      expect(redirectUrl.searchParams.get('scope')).to.equal('openid')
     })
   })
 
@@ -133,7 +153,7 @@ describe('AuthController', () => {
       expect(error).instanceOf(InternalError)
     })
 
-    it("should error if state doesn't match nonce", async () => {
+    it('should error if state format is incorrect', async () => {
       const controller = new AuthController(mockEnv, idpMock, mockLogger)
       const req = mkRequestMock()
 
@@ -147,23 +167,37 @@ describe('AuthController', () => {
       expect(error).instanceOf(ForbiddenError)
     })
 
+    it("should error if state doesn't match nonce", async () => {
+      const controller = new AuthController(mockEnv, idpMock, mockLogger)
+      const req = mkRequestMock()
+
+      let error: unknown
+      try {
+        await controller.redirect(req as unknown as express.Request, 'suffix.invalid', '1234')
+      } catch (err) {
+        error = err
+      }
+
+      expect(error).instanceOf(ForbiddenError)
+    })
+
     it('should clear cookies', async () => {
       const controller = new AuthController(mockEnv, idpMock, mockLogger)
       const req = mkRequestMock()
 
-      await controller.redirect(req as unknown as express.Request, 'nonce', '1234')
+      await controller.redirect(req as unknown as express.Request, 'suffix.nonce', '1234')
 
       const stub = req.res.clearCookie
       expect(stub.callCount).to.equal(2)
-      expect(stub.firstCall.args).to.deep.equal(['VERITABLE_NONCE'])
-      expect(stub.secondCall.args).to.deep.equal(['VERITABLE_REDIRECT'])
+      expect(stub.firstCall.args).to.deep.equal(['VERITABLE_NONCE.suffix'])
+      expect(stub.secondCall.args).to.deep.equal(['VERITABLE_REDIRECT.suffix'])
     })
 
     it('should set token cookies', async () => {
       const controller = new AuthController(mockEnv, idpMock, mockLogger)
       const req = mkRequestMock()
 
-      await controller.redirect(req as unknown as express.Request, 'nonce', '1234')
+      await controller.redirect(req as unknown as express.Request, 'suffix.nonce', '1234')
 
       const stub = req.res.cookie
       expect(stub.callCount).to.equal(2)
@@ -195,7 +229,7 @@ describe('AuthController', () => {
       const controller = new AuthController(mockEnv, idpMock, mockLogger)
       const req = mkRequestMock()
 
-      await controller.redirect(req as unknown as express.Request, 'nonce', '1234')
+      await controller.redirect(req as unknown as express.Request, 'suffix.nonce', '1234')
 
       const stub = req.res.redirect
       expect(stub.calledOnce).equal(true)
@@ -207,8 +241,8 @@ describe('AuthController', () => {
       const req = mkRequestMock()
 
       await controller.redirect(
-        { ...req, signedCookies: { VERITABLE_NONCE: 'nonce' } } as unknown as express.Request,
-        'nonce',
+        { ...req, signedCookies: { 'VERITABLE_NONCE.suffix': 'nonce' } } as unknown as express.Request,
+        'suffix.nonce',
         '1234'
       )
 


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

[VR-208](https://digicatapult.atlassian.net/browse/VR-208)

## High level description

Fixes an infinite redict loop bug on login

## Detailed description

If there are concurrent browser tabs for the same veritable instance a bug can occur if both sessions try to re-authenticate with keycloack at the same time. This is due to each tab trying to authenticate at the same time each overwriting the VERITABLE_NONCE cookie. When this happens another problem occurs where the redirect url is then set to the redirect url. This then leads to the infinite loop.

Changes from this PR:
* nonce and redirect cookies now have dynamic names. this will prevent them from being blatted
* we now check if the redirect will cause a loop back to the redirect page. In that case just go to the root page

## Describe alternatives you've considered

None

## Operational impact

None

## Additional context

None


[VR-208]: https://digicatapult.atlassian.net/browse/VR-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ