### PR TITLE
Switch to our fork of tsimp temporarily

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,7 +1,7 @@
 ignores: [
   '@kitajs/html',
   '@kitajs/ts-html-plugin',
-  'tsimp',
+  '@digicatapult/tsimp',
   'htmx.org',
   'htmx-ext-json-enc',
   'prettier-plugin-organize-imports',

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@digicatapult/tsimp": "^2.0.12",
         "@eslint/eslintrc": "^3.1.0",
         "@eslint/js": "^9.10.0",
         "@playwright/test": "^1.47.0",
@@ -67,7 +68,6 @@
         "prettier-plugin-organize-imports": "^4.0.0",
         "sinon": "^19.0.0",
         "supertest": "^7.0.0",
-        "tsimp": "^2.0.11",
         "typescript": "^5.6.2",
         "undici": "^6.19.8"
       },
@@ -294,6 +294,33 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@digicatapult/tsimp": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@digicatapult/tsimp/-/tsimp-2.0.12.tgz",
+      "integrity": "sha512-eOz7UamXXRDJ9CPKecSvySNLq6Yxl7/DCfRRZ3EcITw6wVGt8lj7FqX35ocETfMMg/98H86G//dLu4xWIqTDig==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cached": "^1.0.1",
+        "@isaacs/catcher": "^1.0.4",
+        "foreground-child": "^3.1.1",
+        "mkdirp": "^3.0.1",
+        "pirates": "^4.0.6",
+        "rimraf": "^5.0.5",
+        "signal-exit": "^4.1.0",
+        "sock-daemon": "^1.4.2",
+        "walk-up-path": "^3.0.1"
+      },
+      "bin": {
+        "tsimp": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
       }
     },
     "node_modules/@digicatapult/tsoa-oauth-express": {
@@ -4824,6 +4851,22 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/mocha": {
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.3.tgz",
@@ -6595,47 +6638,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=14.13.1"
-      }
-    },
-    "node_modules/tsimp": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/tsimp/-/tsimp-2.0.11.tgz",
-      "integrity": "sha512-wRhMmvar8tWHN3ZmykD8f4B4sjCn/f8DFM67LRY+stf/LPa2Kq8ATE2PIi570/DiDJA8kjjxzos3EgP0LmnFLA==",
-      "dev": true,
-      "dependencies": {
-        "@isaacs/cached": "^1.0.1",
-        "@isaacs/catcher": "^1.0.4",
-        "foreground-child": "^3.1.1",
-        "mkdirp": "^3.0.1",
-        "pirates": "^4.0.6",
-        "rimraf": "^5.0.5",
-        "signal-exit": "^4.1.0",
-        "sock-daemon": "^1.4.2",
-        "walk-up-path": "^3.0.1"
-      },
-      "bin": {
-        "tsimp": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.1.0"
-      }
-    },
-    "node_modules/tsimp/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tslib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.8.68",
+  "version": "0.8.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.8.68",
+      "version": "0.8.69",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^0.1.42",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "build": "npm run tsoa:build && tsc",
     "tsoa:build": "tsoa spec-and-routes",
     "tsoa:watch": "node --watch-path=./src ./node_modules/.bin/tsoa -- spec-and-routes",
-    "dev": "npm run tsoa:watch & NODE_ENV=dev node --import=tsimp/import --watch src/index.ts | pino-colada",
-    "dev:init": "NODE_ENV=dev node --import=tsimp/import src/init.ts | pino-colada",
+    "dev": "npm run tsoa:watch & NODE_ENV=dev node --import=@digicatapult/tsimp/import --watch src/index.ts | pino-colada",
+    "dev:init": "NODE_ENV=dev node --import=@digicatapult/tsimp/import src/init.ts | pino-colada",
     "init": "node build/init.js",
     "start": "node build/index.js",
-    "db:cmd": "node --import=tsimp/import ./node_modules/.bin/knex",
+    "db:cmd": "node --import=@digicatapult/tsimp/import ./node_modules/.bin/knex",
     "db:migrate": "npm run db:cmd -- migrate:latest",
     "db:rollback": "npm run db:cmd -- migrate:rollback",
     "db:seed": "npm run db:cmd -- seed:run",
@@ -91,7 +91,7 @@
     "prettier-plugin-organize-imports": "^4.0.0",
     "sinon": "^19.0.0",
     "supertest": "^7.0.0",
-    "tsimp": "^2.0.11",
+    "@digicatapult/tsimp": "^2.0.12",
     "typescript": "^5.6.2",
     "undici": "^6.19.8"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.8.68",
+  "version": "0.8.69",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",

--- a/test/mocharc.json
+++ b/test/mocharc.json
@@ -3,5 +3,5 @@
   "exit": true,
   "extension": "ts",
   "file": ["test/init.ts"],
-  "node-option": ["import=tsimp/import"]
+  "node-option": ["import=@digicatapult/tsimp/import"]
 }


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

ENG-103

## High level description

Swaps out the canonical `tsimp` for our fork `@digicatapult/tsimp` temporarily so our tests run and dev workflows aren't impacted

## Detailed description

This is intended as a temporary fix whilst we decide what to do. Odds are either `tsimp` will update soon and we'll be able to move back or we'll need to look at adjusting our workflow to use something like `swc-node`

## Describe alternatives you've considered

Discussed quite a few with @dblane-digicatapult and this seems the quickest thing to do. 

## Operational impact

None

## Additional context

None
