### PR TITLE
Fix bug where certain cookies aren't being cleared

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.8.72",
+  "version": "0.8.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.8.72",
+      "version": "0.8.73",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^0.1.44",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4786,11 +4786,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.8.72",
+  "version": "0.8.73",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -11,6 +11,7 @@ import { HTMLController } from './HTMLController.js'
 
 const nonceCookieOpts: express.CookieOptions = {
   sameSite: true,
+  maxAge: 10 * 60 * 1000,
   httpOnly: true,
   signed: true,
   secure: true,
@@ -91,7 +92,7 @@ export class AuthController extends HTMLController {
     }
     const [cookieSuffix, redirectNonce] = state.split('.')
     if (!cookieSuffix || !redirectNonce) {
-      req.log.info('incorect format of state parameter %j', { cookieSuffix, redirectNonce })
+      req.log.info('incorrect format of state parameter %j', { cookieSuffix, redirectNonce })
       throw new ForbiddenError('Format of state parameter incorrect')
     }
 
@@ -116,8 +117,8 @@ export class AuthController extends HTMLController {
     req.log.debug(
       'resetting cookies: VERITABLE_NONCE, VERITABLE_REDIRECT, VERITABLE_ACCESS_TOKEN, VERITABLE_REFRESH_TOKEN'
     )
-    res.clearCookie(`VERITABLE_NONCE.${cookieSuffix}`)
-    res.clearCookie(`VERITABLE_REDIRECT.${cookieSuffix}`)
+    res.clearCookie(`VERITABLE_NONCE.${cookieSuffix}`, { path: nonceCookieOpts.path })
+    res.clearCookie(`VERITABLE_REDIRECT.${cookieSuffix}`, { path: nonceCookieOpts.path })
     res.cookie('VERITABLE_ACCESS_TOKEN', access_token, tokenCookieOpts)
     res.cookie('VERITABLE_REFRESH_TOKEN', refresh_token, tokenCookieOpts)
 

--- a/src/controllers/__tests__/auth.test.ts
+++ b/src/controllers/__tests__/auth.test.ts
@@ -70,6 +70,7 @@ describe('AuthController', () => {
       expect(typeof stub.firstCall.args[1]).to.equal('string')
       expect(stub.firstCall.args[2]).to.deep.equal({
         sameSite: true,
+        maxAge: 600000,
         httpOnly: true,
         signed: true,
         secure: true,
@@ -88,6 +89,7 @@ describe('AuthController', () => {
       expect(stub.secondCall.args[1]).to.equal('/example')
       expect(stub.secondCall.args[2]).to.deep.equal({
         sameSite: true,
+        maxAge: 600000,
         httpOnly: true,
         signed: true,
         secure: true,
@@ -106,6 +108,7 @@ describe('AuthController', () => {
       expect(stub.secondCall.args[1]).to.equal('http://www.example.com')
       expect(stub.secondCall.args[2]).to.deep.equal({
         sameSite: true,
+        maxAge: 600000,
         httpOnly: true,
         signed: true,
         secure: true,
@@ -190,8 +193,8 @@ describe('AuthController', () => {
 
       const stub = req.res.clearCookie
       expect(stub.callCount).to.equal(2)
-      expect(stub.firstCall.args).to.deep.equal(['VERITABLE_NONCE.suffix'])
-      expect(stub.secondCall.args).to.deep.equal(['VERITABLE_REDIRECT.suffix'])
+      expect(stub.firstCall.args).to.deep.equal(['VERITABLE_NONCE.suffix', { path: '/auth/redirect' }])
+      expect(stub.secondCall.args).to.deep.equal(['VERITABLE_REDIRECT.suffix', { path: '/auth/redirect' }])
     })
 
     it('should set token cookies', async () => {


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

VR-208

## High level description

Fixes a bug where the nonce and redirect cookies aren't being cleared

## Detailed description

The nonce and redirect cookies should be cleared after a successful login but weren't due to the path not being passed. I've also set a maxAge of 10 minutes on these to be safe.

## Describe alternatives you've considered

N/A

## Operational impact

None

## Additional context

N/A
