### PR TITLE
Change port for smtp4dev from 5000 -> 5001

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ npm run dev
 ```
 
 > :bulb: When service is running, it can be accessed on `http://localhost:3000/`. Api Docs are available on `http://localhost:3000/api-docs` and swagger `http://localhost:3000/swagger/`.
-> If you have opted to use `SMTP_EMAIL` for `EMAIL_TRANSPORT` env you'll find the server on `http://localhost:5000/`.
+> If you have opted to use `SMTP_EMAIL` for `EMAIL_TRANSPORT` env you'll find the server on `http://localhost:5001/`.
 
 ## Environment variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
     image: rnwood/smtp4dev
     container_name: smtp4dev
     ports:
-      - '5000:80' # Port for accessing smtp4dev's web interface
+      - '5001:80' # Port for accessing smtp4dev's web interface
       - '2525:25' # Port for SMTP connections
     restart: always
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^0.1.46",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",

--- a/test/helpers/smtp.ts
+++ b/test/helpers/smtp.ts
@@ -17,7 +17,7 @@ export async function clearSmtp4devMessages() {
   return new Promise((resolve, reject) => {
     const options = {
       hostname: 'localhost',
-      port: 5000,
+      port: 5001,
       path: '/api/messages/*', // Delete all messages
       method: 'DELETE',
       headers: {

--- a/test/integration/smtpEmail.test.ts
+++ b/test/integration/smtpEmail.test.ts
@@ -57,7 +57,7 @@ describe('SMTP email', () => {
     it('should send an email via SMTP', async () => {
       const options = {
         hostname: 'localhost',
-        port: 5000,
+        port: 5001,
         path: '/api/messages',
         method: 'GET',
         headers: {


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/VR-244

## High level description

Port 5000 is reserved on Mac for AirPlay

## Detailed description

Changed ports from 5000 -> 5001 in Docker compose, README and tests


## Describe alternatives you've considered

Turning off AirPort on Mac

## Operational impact

No operational impact

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
