### PR TITLE
Bump hidden dependencies

### DIFF
--- a/docker/keycloak/veritable.json
+++ b/docker/keycloak/veritable.json
@@ -1738,7 +1738,7 @@
     "cibaInterval": "5",
     "realmReusableOtpCode": "false"
   },
-  "keycloakVersion": "24.0.4",
+  "keycloakVersion": "26.2.5",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.15.129",
+  "version": "0.15.130",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.15.129",
+      "version": "0.15.130",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^1.0.30",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.15.129",
+  "version": "0.15.130",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",

--- a/test/testcontainers/testcontainersSetup.ts
+++ b/test/testcontainers/testcontainersSetup.ts
@@ -270,7 +270,7 @@ export async function veritableUIPostgresDbContainer(
   postgresValues: PostgresValuesInterface
 ) {
   const { postgresPassword = 'postgres', postgresUser = 'postgres', postgresDb } = postgresValues
-  const veritableUIPostgresContainer = await new GenericContainer('postgres:17.0-alpine')
+  const veritableUIPostgresContainer = await new GenericContainer('postgres:17.5-alpine')
     .withName(name)
     .withExposedPorts({
       container: exposedPorts.containerPort,
@@ -294,7 +294,7 @@ export async function veritableCloudagentPostgresContainer(
   postgresValues: PostgresValuesInterface
 ) {
   const { postgresPassword = 'postgres', postgresUser = 'postgres', postgresDb } = postgresValues
-  const veritableCloudagentPostgres = await new GenericContainer('postgres:17.0-alpine')
+  const veritableCloudagentPostgres = await new GenericContainer('postgres:17.5-alpine')
     .withName(name)
     .withEnvironment({
       POSTGRES_PASSWORD: postgresPassword,

--- a/test/testcontainers/testcontainersSetup.ts
+++ b/test/testcontainers/testcontainersSetup.ts
@@ -234,7 +234,7 @@ export async function composeKeycloakContainer(
   network: StartedNetwork,
   keycloakDataPath: string
 ): Promise<StartedTestContainer> {
-  const keycloakContainer = await new GenericContainer('quay.io/keycloak/keycloak:26.0.5')
+  const keycloakContainer = await new GenericContainer('quay.io/keycloak/keycloak:26.2.5')
     .withName('keycloak')
     .withExposedPorts({
       container: 8080,


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

<!-- If this PR is linked to a JIRA ticket or Github Issue, please provide the ticket URL here. -->

## High level description

Bumped all hidden version numbers not in `package.json`

## Detailed description

`Keycloak` versions all differ between `docker/keycloak.json`, `docker-compose` and `testcontainersSetup.ts` -> made all consistent `26.2.5`

`Postgres` version differs between `docker-compose` and `testcontainersSetup.ts` -> made consistent `17.5.0`

`veritable-cloudagent` was updated to use `postgres:17.5-alpine` but we were only giving it `postgres:17.0-alpine` in `testcontainersSetup.ts` versioning so `Askar` wallet was failing to connect to the database and initialise.

## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

Tests should now run as expected, however there are still race conditions introduced by pulling and building `playwright` from scratch that might be fixed by pulling the official Microsoft docker image instead.

We should also figure out how to maintain consistent versioning between `docker/keycloak.json`, `docker-compose` and `testcontainersSetup.ts`, and ensure that versions match between `veritable-ui` and `veritable-cloudagent` repos.

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
