### PR TITLE
Replace deprecated Keycloak variables for v26

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     image: quay.io/keycloak/keycloak:26.2.5
     container_name: keycloak
     environment:
-      - KEYCLOAK_ADMIN=admin
-      - KEYCLOAK_ADMIN_PASSWORD=admin
+      - KC_BOOTSTRAP_ADMIN_USERNAME=admin
+      - KC_BOOTSTRAP_ADMIN_PASSWORD=admin
     ports:
       - 3080:8080
     volumes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.15.138",
+  "version": "0.15.139",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.15.138",
+      "version": "0.15.139",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.15.138",
+  "version": "0.15.139",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",

--- a/test/testcontainers/testcontainersSetup.ts
+++ b/test/testcontainers/testcontainersSetup.ts
@@ -241,8 +241,8 @@ export async function composeKeycloakContainer(
       host: 3080,
     })
     .withEnvironment({
-      KEYCLOAK_ADMIN: 'admin',
-      KEYCLOAK_ADMIN_PASSWORD: 'admin',
+      KC_BOOTSTRAP_ADMIN_USERNAME: 'admin',
+      KC_BOOTSTRAP_ADMIN_PASSWORD: 'admin',
     })
     .withBindMounts([{ source: keycloakDataPath, target: '/opt/keycloak/data/import' }]) //this seems necessary
     .withCommand(['start-dev', '--import-realm'])


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix

## High level description

Renovate updated the Keycloak version to v26 in October 2024, but the `KEYCLOAK_ADMIN` and `KEYCLOAK_ADMIN_PASSWORD` environment variables were deprecated and hadn't been updated in the compose with their replacements. This PR swaps the variables out for `KC_BOOTSTRAP_ADMIN_USERNAME` `KC_BOOTSTRAP_ADMIN_PASSWORD` respectively.