### PR TITLE
VR-349 programmatically manage versions of cloudagent, kubo, smtp4dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres-veritable-cloudagent
   veritable-cloudagent-alice:
-    image: digicatapult/veritable-cloudagent:0.13.0
+    image: digicatapult/veritable-cloudagent:v0.13.3
     container_name: veritable-cloudagent-alice
     restart: always
     depends_on:
@@ -182,7 +182,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres-veritable-cloudagent
   veritable-cloudagent-bob:
-    image: digicatapult/veritable-cloudagent:0.13.0
+    image: digicatapult/veritable-cloudagent:v0.13.3
     container_name: veritable-cloudagent-bob
     restart: always
     depends_on:
@@ -270,7 +270,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres-veritable-cloudagent
   veritable-cloudagent-charlie:
-    image: digicatapult/veritable-cloudagent:0.13.0
+    image: digicatapult/veritable-cloudagent:v0.13.3
     container_name: veritable-cloudagent-charlie
     restart: always
     depends_on:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.16.7",
+  "version": "0.16.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.16.7",
+      "version": "0.16.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.16.8",
+  "version": "0.16.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.16.8",
+      "version": "0.16.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.16.8",
+  "version": "0.16.9",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.16.7",
+  "version": "0.16.8",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",

--- a/test/testcontainers/testcontainersSetup.ts
+++ b/test/testcontainers/testcontainersSetup.ts
@@ -22,7 +22,7 @@ interface VeritableCloudAgentEnvConfig extends PostgresPasswordAndUser {
   walletId: string
   walletKey: string
   postgresHost: string
-  logLevel?: 'debug' | 'info' | 'warn' | 'error'
+  logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error'
   inboundTransport?: string
   outboundTransport?: string
   adminPort?: string

--- a/test/testcontainers/testcontainersSetup.ts
+++ b/test/testcontainers/testcontainersSetup.ts
@@ -22,7 +22,7 @@ interface VeritableCloudAgentEnvConfig extends PostgresPasswordAndUser {
   walletId: string
   walletKey: string
   postgresHost: string
-  logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error'
+  logLevel?: 'debug' | 'info' | 'warn' | 'error'
   inboundTransport?: string
   outboundTransport?: string
   adminPort?: string

--- a/test/testcontainers/testcontainersSetup.ts
+++ b/test/testcontainers/testcontainersSetup.ts
@@ -69,6 +69,9 @@ const dockerCompose = fs.readFileSync('./docker-compose.yml', 'utf-8')
 const parsed = parse(dockerCompose)
 const keycloakVersion = parsed.services.keycloak.image
 const postgresVersion = parsed.services['postgres-veritable-ui-alice'].image
+const cloudagentVersion = parsed.services['veritable-cloudagent-alice'].image
+const kuboVersion = parsed.services.ipfs.image
+const smtp4devVersion = parsed.services.smtp4dev.image
 
 export async function bringUpSharedContainers() {
   const __filename = fileURLToPath(import.meta.url)
@@ -262,7 +265,7 @@ export async function composeKeycloakContainer(
 }
 
 export async function composeIpfsContainer(network: StartedNetwork): Promise<StartedTestContainer> {
-  const ipfsContainer = await new GenericContainer('ipfs/kubo:release')
+  const ipfsContainer = await new GenericContainer(kuboVersion)
     .withName('ipfs')
     .withWaitStrategy(Wait.forLogMessage('Gateway server listening on'))
     .withNetwork(network)
@@ -337,7 +340,7 @@ export async function cloudagentContainer(
     postgresPort = '5432',
     label = 'veritable-cloudagent',
   } = env
-  const cloudagentContainer = await new GenericContainer('digicatapult/veritable-cloudagent')
+  const cloudagentContainer = await new GenericContainer(cloudagentVersion)
     .withName(name)
     .withExposedPorts({
       container: exposedPorts.containerPort,
@@ -367,7 +370,7 @@ export async function cloudagentContainer(
 
 // would we ever want to change anything about this?
 export async function composeSmtp4dev(network: StartedNetwork) {
-  const smtp4dev = await new GenericContainer('rnwood/smtp4dev')
+  const smtp4dev = await new GenericContainer(smtp4devVersion)
     .withName('smtp4dev')
     .withExposedPorts({
       container: 80,


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Chore

## Linked tickets

https://digicatapult.atlassian.net/browse/VR-349

## High level description

Use versions of `veritable-cloudagent`, `kubo` and `smtp4dev` from `docker-compose` in `testcontainersSetup.ts`

## Detailed description

Same pattern as VR-319. Parse `docker-compose.yml` to extract keys corresponding to pinned versions of `veritable-cloudagent`, `kubo` and `smtp4dev` to allow these to come under the control of `Renovate` in `testcontainersSetup.ts`

## Describe alternatives you've considered

## Operational impact

## Additional context
