### PR TITLE
Bug/node22.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^2.0.16",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "scripts": {
     "depcheck": "depcheck",
-    "test:unit": "NODE_ENV=test ./node_modules/.bin/mocha --config ./test/mocharc.json --file ./test/init-unit.ts ./src/**/*.test.ts",
-    "test:integration": "NODE_ENV=test ./node_modules/.bin/mocha --config ./test/mocharc.json --file ./test/init.ts ./test/**/*.test.ts",
+    "test:unit": "NODE_OPTIONS='--no-experimental-strip-types' NODE_ENV=test ./node_modules/.bin/mocha --config ./test/mocharc.json --file ./test/init-unit.ts ./src/**/*.test.ts",
+    "test:integration": "NODE_OPTIONS='--no-experimental-strip-types' NODE_ENV=test ./node_modules/.bin/mocha --config ./test/mocharc.json --file ./test/init.ts ./test/**/*.test.ts",
     "test:e2e": "playwright test --trace on --max-failures=1",
     "test:playwright": "playwright test --ui",
     "check": "npm run tsoa:build && tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets



## High level description

Urgent bugfix to temporarily deal with breaking changes between `node 22.17.1` and `node 22.18.0`

## Detailed description

Node 22 have included an experimental type stripping feature into an LTS branch (https://github.com/nodejs/node/issues/59364). Now need to use `NODE_OPTIONS="--no-experimental-strip-types"` in all files

Adding `NODE_OPTIONS="--no-experimental-strip-types"` works for now. Ideally fixed upstream.

## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

Projects will keep working as CI and elsewhere version bumps `node 22`

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
