### PR TITLE
VR 362 hangup logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.19.6",
+      "version": "0.19.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^2.0.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",

--- a/src/controllers/connection/newConnection.ts
+++ b/src/controllers/connection/newConnection.ts
@@ -483,6 +483,7 @@ export class NewConnectionController extends HTMLController {
           }
         })
         // Make sure we're only deleting invitations we've sent
+        // TODO: review need to delete OOB invite in this workflow
         if (exists && exists.role === 'sender') {
           await this.cloudagent.deleteOutOfBandInvite(invite.oob_invite_id)
           logger.debug('OOB invitation deleted %s', invite.oob_invite_id)

--- a/src/services/connectionEvents.ts
+++ b/src/services/connectionEvents.ts
@@ -65,24 +65,16 @@ export default class ConnectionEvents {
 
   private connectionDidRotatedHandler: eventData<'ConnectionDidRotated'> = async (event) => {
     this.logger.debug(`new DID rotation event %j`, event.payload)
-    const { outOfBandId, state: connectionState } = event.payload.connectionRecord
+    const { id: cloudAgentConnectionId, state: connectionState } = event.payload.connectionRecord
 
     await this.db.withTransaction(async (db) => {
-      // Get the connection id from the OOB invitation id in the event payload
-      // TODO: figure out how to catch this event if we are using direct DID-mediated connections
-      // at present the event from credo-ts doesn't emit any of their DIDs if one is invalidated
-      // and the connection record
-      const [outOfBandRecord] = await db.get('connection_invite', {
-        oob_invite_id: outOfBandId,
-      })
-      const { connection_id: cloudAgentConnectionId } = outOfBandRecord
       // If this is a disconnection event (ie rotated to 0/null/undefined)
       if (!event.payload.theirDid?.to && connectionState === 'completed') {
         this.logger.warn('Connection %s has disconnected from us', cloudAgentConnectionId)
         // Mark as disconnected in db
-        await this.db.update(
+        await db.update(
           'connection',
-          { id: cloudAgentConnectionId, status: 'verified_both' },
+          { agent_connection_id: cloudAgentConnectionId, status: 'verified_both' },
           { status: 'disconnected' }
         )
       }

--- a/src/services/connectionEvents.ts
+++ b/src/services/connectionEvents.ts
@@ -70,6 +70,8 @@ export default class ConnectionEvents {
     await this.db.withTransaction(async (db) => {
       // Get the connection id from the OOB invitation id in the event payload
       // TODO: figure out how to catch this event if we are using direct DID-mediated connections
+      // at present the event from credo-ts doesn't emit any of their DIDs if one is invalidated
+      // and the connection record
       const [outOfBandRecord] = await db.get('connection_invite', {
         oob_invite_id: outOfBandId,
       })

--- a/src/services/connectionEvents.ts
+++ b/src/services/connectionEvents.ts
@@ -19,6 +19,7 @@ export default class ConnectionEvents {
 
   public start() {
     this.cloudagent.on('ConnectionStateChanged', this.connectionStateChangedHandler)
+    this.cloudagent.on('ConnectionDidRotated', this.connectionDidRotatedHandler)
   }
 
   private connectionStateChangedHandler: eventData<'ConnectionStateChanged'> = async (event) => {
@@ -60,5 +61,9 @@ export default class ConnectionEvents {
       )
       return
     })
+  }
+
+  private connectionDidRotatedHandler: eventData<'ConnectionDidRotated'> = async (event) => {
+    this.logger.debug(`new DID rotation event %j`, event.payload)
   }
 }

--- a/src/services/veritableCloudagentEvents.ts
+++ b/src/services/veritableCloudagentEvents.ts
@@ -27,7 +27,7 @@ const eventParser = z.discriminatedUnion('type', [
     type: z.literal('ConnectionDidRotated'),
     payload: z.object({
       connectionRecord: connectionParser,
-      theirDid: z.object({ to: z.string() }).optional(),
+      theirDid: z.object({ from: z.string(), to: z.string() }).optional(),
     }),
   }),
   z.object({
@@ -138,7 +138,7 @@ export default class VeritableCloudagentEvents extends IndexedAsyncEventEmitter<
             break
           case 'ConnectionDidRotated':
             id = data.payload.connectionRecord.id
-            this.logger.debug('DID rotation event on connection %s', id)
+            this.logger.trace('DID rotation event on connection %s', id)
             break
           case 'CredentialStateChanged':
             id = data.payload.credentialRecord.id

--- a/src/services/veritableCloudagentEvents.ts
+++ b/src/services/veritableCloudagentEvents.ts
@@ -17,21 +17,26 @@ const drpcRequestParser = z.object({
   params: z.record(z.any(), z.any()).optional(),
   id: z.uuid(),
 })
+
 const eventParser = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('ConnectionStateChanged'),
+    payload: z.object({ connectionRecord: connectionParser }),
+  }),
+  z.object({
+    type: z.literal('ConnectionDidRotated'),
     payload: z.object({
       connectionRecord: connectionParser,
+      // ourDid: z.object({ from: z.string(), to: z.string() }).optional(),
+      theirDid: z.object({ from: z.string(), to: z.string() }).optional(),
     }),
   }),
   z.object({
     type: z.literal('CredentialStateChanged'),
-    payload: z.object({
-      credentialRecord: credentialParser,
-    }),
+    payload: z.object({ credentialRecord: credentialParser }),
   }),
   z.object({ type: z.literal('BasicMessageStateChanged'), payload: z.object({}) }),
-  z.object({ type: z.literal('ConnectionDidRotated'), payload: z.object({}) }),
+  // z.object({ type: z.literal('ConnectionDidRotated'), payload: z.object({}) }),
   z.object({ type: z.literal('RevocationNotificationReceived'), payload: z.object({}) }),
   z.object({
     type: z.literal('DrpcRequestStateChanged'),
@@ -132,6 +137,10 @@ export default class VeritableCloudagentEvents extends IndexedAsyncEventEmitter<
           case 'ConnectionStateChanged':
             id = data.payload.connectionRecord.id
             connectionSeen.add(id)
+            break
+          case 'ConnectionDidRotated':
+            id = data.payload.connectionRecord.id
+            this.logger.trace('DID rotation event on connection %s', id)
             break
           case 'CredentialStateChanged':
             id = data.payload.credentialRecord.id

--- a/src/services/veritableCloudagentEvents.ts
+++ b/src/services/veritableCloudagentEvents.ts
@@ -27,8 +27,7 @@ const eventParser = z.discriminatedUnion('type', [
     type: z.literal('ConnectionDidRotated'),
     payload: z.object({
       connectionRecord: connectionParser,
-      // ourDid: z.object({ from: z.string(), to: z.string() }).optional(),
-      theirDid: z.object({ from: z.string(), to: z.string() }).optional(),
+      theirDid: z.object({ to: z.string() }).optional(),
     }),
   }),
   z.object({
@@ -36,7 +35,6 @@ const eventParser = z.discriminatedUnion('type', [
     payload: z.object({ credentialRecord: credentialParser }),
   }),
   z.object({ type: z.literal('BasicMessageStateChanged'), payload: z.object({}) }),
-  // z.object({ type: z.literal('ConnectionDidRotated'), payload: z.object({}) }),
   z.object({ type: z.literal('RevocationNotificationReceived'), payload: z.object({}) }),
   z.object({
     type: z.literal('DrpcRequestStateChanged'),
@@ -140,7 +138,7 @@ export default class VeritableCloudagentEvents extends IndexedAsyncEventEmitter<
             break
           case 'ConnectionDidRotated':
             id = data.payload.connectionRecord.id
-            this.logger.trace('DID rotation event on connection %s', id)
+            this.logger.debug('DID rotation event on connection %s', id)
             break
           case 'CredentialStateChanged':
             id = data.payload.credentialRecord.id


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Feature

## Linked tickets

https://digicatapult.atlassian.net/browse/VR-362

## High level description

Hangup logic & websocket event

## Detailed description

Work in progress - this relies on `credo-ts 0.5.17-alpha` which has the hangup handler emit a socket event. This needs to be merged and released as `0.5.17` before we can merge this ticket

So far have implemented socket event and updating `veritable-ui` db state to `disconnected` on a `hangup` event

## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
