### PR TITLE
bugfix ssl none in keycloak

### DIFF
--- a/docker/keycloak/veritable.json
+++ b/docker/keycloak/veritable.json
@@ -25,7 +25,7 @@
   "oauth2DeviceCodeLifespan": 600,
   "oauth2DevicePollingInterval": 5,
   "enabled": true,
-  "sslRequired": "external",
+  "sslRequired": "none",
   "registrationAllowed": true,
   "registrationEmailAsUsername": false,
   "rememberMe": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.20.22",
+  "version": "0.20.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.20.22",
+      "version": "0.20.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^2.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.20.22",
+  "version": "0.20.23",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

https://digicatapult.atlassian.net/browse/VR-506

## High level description

Change keycloak to use `sslRequired: none` instead of `external`

## Detailed description

<!-- A detailed description of the feature and if possible describe how has been implemented. -->


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

Allows us to use Docker > `4.42.1`
