### PR TITLE
Add migration-checks to test and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
       migrations_dir: src/models/db/migrations
       postgres_image: postgres:18.4-alpine
       db_name: veritable-ui
-      seed_command: 'npm run db:seed'
 
   build-docker:
     needs: [e2e-tests-npm, tests-npm, static-checks-npm, migration-checks]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,18 @@ jobs:
     secrets:
       DTRACK_APIKEY: ${{ secrets.DTRACK_APIKEY }}
       DTRACK_HOSTNAME: ${{ secrets.DTRACK_HOSTNAME }}
+  migration-checks:
+    uses: digicatapult/shared-workflows/.github/workflows/migration-checks-npm.yml@main
+    permissions:
+      contents: read
+    with:
+      migrations_dir: src/models/db/migrations
+      postgres_image: postgres:18.4-alpine
+      db_name: veritable-ui
+      seed_command: 'npm run db:seed'
+
   build-docker:
-    needs: [e2e-tests-npm, tests-npm, static-checks-npm]
+    needs: [e2e-tests-npm, tests-npm, static-checks-npm, migration-checks]
     uses: digicatapult/shared-workflows/.github/workflows/build-docker.yml@main
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,16 @@ on:
   push:
     branches-ignore: ['main']
 jobs:
+  migration-checks:
+    uses: digicatapult/shared-workflows/.github/workflows/migration-checks-npm.yml@main
+    permissions:
+      contents: read
+    with:
+      migrations_dir: src/models/db/migrations
+      postgres_image: postgres:18.4-alpine
+      db_name: veritable-ui
+      seed_command: 'npm run db:seed'
+
   static-checks-npm:
     uses: digicatapult/shared-workflows/.github/workflows/static-checks-npm.yml@main
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
       migrations_dir: src/models/db/migrations
       postgres_image: postgres:18.4-alpine
       db_name: veritable-ui
-      seed_command: 'npm run db:seed'
 
   static-checks-npm:
     uses: digicatapult/shared-workflows/.github/workflows/static-checks-npm.yml@main

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.21.111",
+  "version": "0.21.112",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.21.111",
+      "version": "0.21.112",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^2.0.65",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.21.111",
+  "version": "0.21.112",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",

--- a/src/models/db/migrations/20240730121459_query-table-refinements.ts
+++ b/src/models/db/migrations/20240730121459_query-table-refinements.ts
@@ -64,6 +64,9 @@ export async function down(knex: Knex): Promise<void> {
   await knex.raw('DROP TYPE query_status_old')
 
   await knex.schema.dropTable('query_rpc')
+  // Native enum types are not removed by dropping the table that used them.
+  await knex.raw('DROP TYPE query_rpc_method')
+  await knex.raw('DROP TYPE query_rpc_role')
 
   await knex.schema.alterTable('query', (def) => {
     def.string('details').notNullable().alter()

--- a/src/models/db/migrations/20240808125209_query_tables_additional_column.ts
+++ b/src/models/db/migrations/20240808125209_query_tables_additional_column.ts
@@ -20,4 +20,6 @@ export async function down(knex: Knex): Promise<void> {
     def.dropColumn('query_response')
     def.dropColumn('role')
   })
+  // Native enum type is not removed by dropping the column that used it.
+  await knex.raw('DROP TYPE query_role')
 }

--- a/src/models/db/migrations/20241029141709_update-response-column-type.ts
+++ b/src/models/db/migrations/20241029141709_update-response-column-type.ts
@@ -23,8 +23,8 @@ export async function down(knex: Knex): Promise<void> {
   await knex.schema.alterTable('query', (def) => {
     def.dropColumn('response')
     def.dropColumn('type')
+    def.string('query_type').notNullable()
     def.string('query_response').nullable()
-    def.string('query_response').notNullable()
   })
 
   await knex.raw('DROP TYPE query_type')

--- a/src/models/db/migrations/20250709174015_add-query-type.ts
+++ b/src/models/db/migrations/20250709174015_add-query-type.ts
@@ -1,9 +1,14 @@
 import { Knex } from 'knex'
 
 export const up = async (knex: Knex): Promise<void> => {
-  await knex.raw('ALTER TYPE "query_type" ADD VALUE \'beneficiary_account_validation\'')
+  // IF NOT EXISTS keeps this idempotent: the value is already present on any
+  // database where this migration previously ran, and the up/down/up rollback
+  // check re-applies it after a rollback.
+  await knex.raw('ALTER TYPE "query_type" ADD VALUE IF NOT EXISTS \'beneficiary_account_validation\'')
 }
 
-export const down = async (knex: Knex): Promise<void> => {
-  await knex.raw('ALTER TYPE "query_type" REMOVE VALUE \'beneficiary_account_validation\'')
+export const down = async (_knex: Knex): Promise<void> => {
+  // PostgreSQL cannot remove a value from an enum type, so this migration is
+  // intentionally irreversible. The previous down used `ALTER TYPE ... REMOVE
+  // VALUE`, which is not valid SQL and failed on rollback.
 }

--- a/src/models/db/migrations/20250730102618_add_3rd_party_boolean.ts
+++ b/src/models/db/migrations/20250730102618_add_3rd_party_boolean.ts
@@ -15,6 +15,20 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
+  // The up dropped organisation_registries; recreate it here so this down
+  // reverses the up (and so the earlier migration's own down can drop it).
+  const now = () => knex.fn.now()
+  await knex.schema.createTable('organisation_registries', (def) => {
+    def.uuid('id').defaultTo(knex.raw('uuid_generate_v4()'))
+    def.string('country_code').notNullable()
+    def.string('registry_key').notNullable()
+    def.string('registry_name').notNullable()
+    def.string('url')
+    def.string('api_key')
+    def.datetime('created_at').notNullable().defaultTo(now())
+    def.datetime('updated_at').notNullable().defaultTo(now())
+  })
+
   await knex.schema.alterTable('connection', (def) => {
     def.dropColumn('registry_code')
   })


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [ ] Bug Fix
- [x] Chore
- [ ] Feature

## Linked tickets

[ENG-313](https://digicatapult.atlassian.net/browse/ENG-313)

## High level description

Adopts the `migration-checks-npm` shared workflow so bad knex migrations are caught in CI, on both the **test** and **release** workflows.

## Detailed description

Adds a `migration-checks` job (immutability/ordering lint, up/down/up rollback roundtrip, seeded-upgrade) to the test workflow and to `release.yml`, where the docker build is gated on it. Postgres is provided via the `postgres_image` fallback (postgres:18.4-alpine, db veritable-ui, with db:seed) rather than the caller's compose service, because this repo's compose is a multi-service testnet whose `postgres` isn't a plain single service. Migrations dir: `src/models/db/migrations`.

## Describe alternatives you've considered

Bringing up the repo's compose `postgres` service — avoided because the testnet compose doesn't validate/instantiate cleanly for a single service in CI.

## Operational impact

CI-only. Adds a job to the test workflow and a pre-build gate on release.

## Additional context

Part of the org-wide ENG-313 migration-checks rollout.

[ENG-313]: https://digicatapult.atlassian.net/browse/ENG-313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ