### PR TITLE
Upgrade runtime npm to patch node-tar CVE-2026-59873

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN npm run build
 # Service
 FROM node:24-alpine AS service
 
+RUN npm install -g npm@12.0.1
+
 WORKDIR /veritable-ui
 
 RUN apk add --no-cache coreutils curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1.25
 FROM node:24-alpine AS builder
 
+RUN npm install -g npm@12.0.1
+
 WORKDIR /veritable-ui
 
 COPY package*.json ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.21.113",
+  "version": "0.21.114",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.21.113",
+      "version": "0.21.114",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^2.0.65",

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
       },
       "engines": {
         "node": "24.x",
-        "npm": "11.x"
+        "npm": "12.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.21.113",
+  "version": "0.21.114",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": "24.x",
-    "npm": "11.x"
+    "npm": "12.x"
   },
   "scripts": {
     "depcheck": "depcheck",


### PR DESCRIPTION
# Pull Request

## Checklist
- [ ] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

<!-- If this PR is linked to a JIRA ticket or GitHub Issue, please provide the ticket URL here. -->

## High level description

- Upgrade to npm 12 because npm 11 produces a [CVE error](https://github.com/digicatapult/veritable-ui/actions/runs/30312638517/job/90131675588).


## Detailed description


## Additional context

