### PR TITLE
Add missing Dependency-Track secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
     secrets:
       DTRACK_APIKEY: ${{ secrets.DTRACK_APIKEY }}
       DTRACK_HOSTNAME: ${{ secrets.DTRACK_HOSTNAME }}
+      DTRACK_PARENT_GUID: ${{ secrets.DTRACK_PARENT_GUID }}
   migration-checks:
     uses: digicatapult/shared-workflows/.github/workflows/migration-checks-npm.yml@main
     permissions:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "veritable-ui",
-  "version": "0.21.115",
+  "version": "0.21.116",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "veritable-ui",
-      "version": "0.21.115",
+      "version": "0.21.116",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/tsoa-oauth-express": "^2.0.65",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritable-ui",
-  "version": "0.21.115",
+  "version": "0.21.116",
   "description": "UI for Veritable",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

ENG-323

## High level description

`DTRACK_PARENT_GUID: ${{ secrets.DTRACK_PARENT_GUID }}` was expected by an upstream change to the shared workflows, but it was never picked up per downstream caller. This has been tested already against [digicatapult/hello-world](https://github.com/digicatapult/hello-world).